### PR TITLE
Update .env.local.template

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_MODE=UNLIMITED # Optional values LIMITED/UNLIMITED
 
-FALKORDB_URL=redis://localhost:6379 # FALKORDB_URL
+FALKORDB_URL=redis://localhost:6379 # Updated to redis:// protocol for compatibility with Redis client
 
 OPENAI_API_KEY=[API_KEY] # Set you openai api key here
 

--- a/.env.local.template
+++ b/.env.local.template
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_MODE=UNLIMITED # Optional values LIMITED/UNLIMITED
 
-FALKORDB_URL=falkordb://localhost:6379 # FALKORDB_URL
+FALKORDB_URL=redis://localhost:6379 # FALKORDB_URL
 
 OPENAI_API_KEY=[API_KEY] # Set you openai api key here
 


### PR DESCRIPTION
**Description**:
Changing the URL protocol from `falkordb` to `redis` resolves the unrecognized protocol issue from the Redis client library that FalkorDB uses.

**Issue**:
The ```falkordb://``` prefix on the URL is unrecognized by the Redis client, which expects the protocol to be either redis:// for unencrypted connections or rediss:// for TLS/SSL. It's causing the error: `⨯ TypeError: Invalid protocol
    at RedisClient.parseURL (webpack-internal:///(rsc)/./node_modules/@falkordb/client/dist/lib/client/index.js:60:19)`. The error roots from the `parseURL` method in the `RedisClient` class of respective `node_module`, where it specifies the required aforementioned protocols (redis:// or rediss://) and otherwise returns the 'Invalid protocol' error. 

**Dependencies**:
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the database URL configuration in the environment template file to use a new value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->