### PR TITLE
Add API documentation for graph retrieval, query, and commit history endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,4 +246,41 @@ A C analyzer exists in the source tree, but it is commented out and is not curre
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
+Knowledge Graph, Code Analysis, Code Visualization, Dead Code Analysis, Graph Database
+
+## API Reference
+
+### Retrieve a graph
+
+Fetch graph entities from a repository:
+
+```bash
+curl -X GET "http://127.0.0.1:5000/graph_entities?repo=<REPO_NAME>" -H "Authorization: ${SECRET_TOKEN}"
+```
+
+Example:
+```bash
+curl -X GET "http://127.0.0.1:5000/graph_entities?repo=GraphRAG-SDK" -H "Authorization: ${SECRET_TOKEN}"
+```
+
+### Send Query
+
+Query your code graph using natural language:
+
+```bash
+curl -X POST http://127.0.0.1:5000/chat -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>", "msg": "<YOUR_QUESTION>"}' -H "Authorization: ${SECRET_TOKEN}"
+```
+
+### History change
+
+List all commits:
+```bash
+curl -X POST http://127.0.0.1:5000/list_commits -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>"}' -H "Authorization: ${SECRET_TOKEN}"
+```
+
+Switch to a specific commit:
+```bash
+curl -X POST http://127.0.0.1:5000/switch_commit -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>", "commit": "<COMMIT_HASH>"}' -H "Authorization: ${SECRET_TOKEN}"
+```
+
 Copyright FalkorDB Ltd. 2025

--- a/README.md
+++ b/README.md
@@ -246,8 +246,6 @@ A C analyzer exists in the source tree, but it is commented out and is not curre
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-Knowledge Graph, Code Analysis, Code Visualization, Dead Code Analysis, Graph Database
-
 ## API Reference
 
 ### Retrieve a graph
@@ -255,12 +253,12 @@ Knowledge Graph, Code Analysis, Code Visualization, Dead Code Analysis, Graph Da
 Fetch graph entities from a repository:
 
 ```bash
-curl -X GET "http://127.0.0.1:5000/graph_entities?repo=<REPO_NAME>" -H "Authorization: ${SECRET_TOKEN}"
+curl -X GET "http://127.0.0.1:5000/api/graph_entities?repo=<REPO_NAME>" -H "Authorization: Bearer ${SECRET_TOKEN}"
 ```
 
 Example:
 ```bash
-curl -X GET "http://127.0.0.1:5000/graph_entities?repo=GraphRAG-SDK" -H "Authorization: ${SECRET_TOKEN}"
+curl -X GET "http://127.0.0.1:5000/api/graph_entities?repo=GraphRAG-SDK" -H "Authorization: Bearer ${SECRET_TOKEN}"
 ```
 
 ### Send Query
@@ -268,19 +266,19 @@ curl -X GET "http://127.0.0.1:5000/graph_entities?repo=GraphRAG-SDK" -H "Authori
 Query your code graph using natural language:
 
 ```bash
-curl -X POST http://127.0.0.1:5000/chat -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>", "msg": "<YOUR_QUESTION>"}' -H "Authorization: ${SECRET_TOKEN}"
+curl -X POST http://127.0.0.1:5000/api/chat -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>", "msg": "<YOUR_QUESTION>"}' -H "Authorization: Bearer ${SECRET_TOKEN}"
 ```
 
-### History change
+### Commit history
 
 List all commits:
 ```bash
-curl -X POST http://127.0.0.1:5000/list_commits -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>"}' -H "Authorization: ${SECRET_TOKEN}"
+curl -X POST http://127.0.0.1:5000/api/list_commits -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>"}' -H "Authorization: Bearer ${SECRET_TOKEN}"
 ```
 
 Switch to a specific commit:
 ```bash
-curl -X POST http://127.0.0.1:5000/switch_commit -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>", "commit": "<COMMIT_HASH>"}' -H "Authorization: ${SECRET_TOKEN}"
+curl -X POST http://127.0.0.1:5000/api/switch_commit -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>", "commit": "<COMMIT_HASH>"}' -H "Authorization: Bearer ${SECRET_TOKEN}"
 ```
 
 Copyright FalkorDB Ltd. 2025

--- a/README.md
+++ b/README.md
@@ -242,43 +242,40 @@ A C analyzer exists in the source tree, but it is commented out and is not curre
 | POST | `/api/analyze_repo` | Clone and analyze a git repository |
 | POST | `/api/switch_commit` | Switch the indexed repository to a specific commit |
 
-## License
+### Usage examples
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## API Reference
-
-### Retrieve a graph
-
-Fetch graph entities from a repository:
-
+Fetch graph entities:
 ```bash
-curl -X GET "http://127.0.0.1:5000/api/graph_entities?repo=<REPO_NAME>" -H "Authorization: Bearer ${SECRET_TOKEN}"
+curl -X GET "http://127.0.0.1:5000/api/graph_entities?repo=<REPO_NAME>" \
+  -H "Authorization: Bearer <YOUR_SECRET_TOKEN>"
 ```
-
-Example:
-```bash
-curl -X GET "http://127.0.0.1:5000/api/graph_entities?repo=GraphRAG-SDK" -H "Authorization: Bearer ${SECRET_TOKEN}"
-```
-
-### Send Query
 
 Query your code graph using natural language:
-
 ```bash
-curl -X POST http://127.0.0.1:5000/api/chat -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>", "msg": "<YOUR_QUESTION>"}' -H "Authorization: Bearer ${SECRET_TOKEN}"
+curl -X POST http://127.0.0.1:5000/api/chat \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <YOUR_SECRET_TOKEN>" \
+  -d '{"repo": "<REPO_NAME>", "msg": "<YOUR_QUESTION>"}'
 ```
-
-### Commit history
 
 List all commits:
 ```bash
-curl -X POST http://127.0.0.1:5000/api/list_commits -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>"}' -H "Authorization: Bearer ${SECRET_TOKEN}"
+curl -X POST http://127.0.0.1:5000/api/list_commits \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <YOUR_SECRET_TOKEN>" \
+  -d '{"repo": "<REPO_NAME>"}'
 ```
 
 Switch to a specific commit:
 ```bash
-curl -X POST http://127.0.0.1:5000/api/switch_commit -H "Content-Type: application/json" -d '{"repo": "<REPO_NAME>", "commit": "<COMMIT_HASH>"}' -H "Authorization: Bearer ${SECRET_TOKEN}"
+curl -X POST http://127.0.0.1:5000/api/switch_commit \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <YOUR_SECRET_TOKEN>" \
+  -d '{"repo": "<REPO_NAME>", "commit": "<COMMIT_HASH>"}'
 ```
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 Copyright FalkorDB Ltd. 2025


### PR DESCRIPTION
Migrated from [falkordb/code-graph-backend#96](https://github.com/FalkorDB/code-graph-backend/pull/96)

## Summary
Adds an API Reference section to the README documenting:
1. **Retrieve a graph** (`GET /graph_entities`)
2. **Send Query** (`POST /chat`)
3. **History change** (`POST /list_commits`, `POST /switch_commit`)

Resolves #534

---
*Originally authored by @Copilot in [falkordb/code-graph-backend#96](https://github.com/FalkorDB/code-graph-backend/pull/96)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Usage examples" section to the README with concrete curl commands demonstrating how to call the /api/graph_entities (GET), /api/chat (POST), /api/list_commits (POST), and /api/switch_commit (POST) endpoints, including required Authorization: Bearer <YOUR_SECRET_TOKEN> header and example request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->