### PR TITLE
Fix prismjs DOM Clobbering vulnerability (Dependabot #45)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4380,15 +4380,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/refractor/node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -41,6 +41,9 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2"
   },
+  "overrides": {
+    "prismjs": "^1.30.0"
+  },
   "devDependencies": {
     "@types/node": "^20.19.4",
     "@types/react": "^18.3.18",


### PR DESCRIPTION
## Summary

Fixes the **prismjs DOM Clobbering vulnerability** ([Dependabot alert #45](https://github.com/FalkorDB/code-graph/security/dependabot/45)).

### Change
Added an npm `overrides` section in `app/package.json` to force `prismjs ^1.30.0`, eliminating the vulnerable `1.27.0` version that was nested under `refractor 3.x` (transitive dependency of `react-syntax-highlighter`).

### Verification
- Frontend builds successfully
- `npm audit` reports 0 vulnerabilities

### Remaining alerts (not fixable here)
| Alert | Package | Blocked by |
|-------|---------|-----------|
| #47–60 (14 alerts) | pypdf <6.0.0 | `graphrag-sdk 0.8.2` pins `pypdf>=5.9.0,<6.0.0` |
| #46 | requests <2.32.4 | `multilspy` pins `requests==2.32.3` |

These require upstream dependency updates to resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a top-level overrides entry that pins prismjs to ^1.30.0 for dependency resolution.
  * Ensures a consistent prismjs version is used during installs, reducing variation across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->