### PR TITLE
fix(test): update tests for entity class refactoring

### DIFF
--- a/api/graph.py
+++ b/api/graph.py
@@ -426,9 +426,10 @@ class Graph():
 
         return None
 
-    def get_file(self, path: str, name: str, ext: str) -> Optional[File]:
+    def get_file(self, path: str, name: str, ext: str) -> Optional[Node]:
         """
-        Retrieves a File entity from the graph database based on its path, name, and extension.
+        Retrieves a File node from the graph database based on its path, name,
+        and extension.
 
         Args:
             path (str): The file path.
@@ -436,12 +437,7 @@ class Graph():
             ext (str): The file extension.
 
         Returns:
-            Optional[File]: The File object if found, otherwise None.
-
-        This method constructs and executes a query to find a file node in the graph
-        database with the specified path, name, and extension. If the file node is found,
-        it creates and returns a File object with its properties and ID. If no such node
-        is found, it returns None.
+            Optional[Node]: The File node if found, otherwise None.
 
         Example:
             file = self.get_file('/path/to/file', 'filename', '.py')
@@ -452,19 +448,10 @@ class Graph():
         params = {'path': path, 'name': name, 'ext': ext}
 
         res = self._query(q, params)
-        if(len(res.result_set) == 0):
+        if len(res.result_set) == 0:
             return None
 
-        node = res.result_set[0][0]
-
-        ext  = node.properties['ext']
-        path = node.properties['path']
-        name = node.properties['name']
-        file = File(path, name, ext)
-
-        file.id = node.id
-
-        return file
+        return res.result_set[0][0]
 
     # set file code coverage
     # if file coverage is 100% set every defined function coverage to 100% aswell

--- a/tests/test_c_analyzer.py
+++ b/tests/test_c_analyzer.py
@@ -2,7 +2,8 @@ import os
 import unittest
 from pathlib import Path
 
-from api import SourceAnalyzer, File, Struct, Function, Graph
+from api import SourceAnalyzer, Graph
+
 
 class Test_C_Analyzer(unittest.TestCase):
     def test_analyzer(self):
@@ -24,37 +25,44 @@ class Test_C_Analyzer(unittest.TestCase):
         analyzer.analyze_local_folder(path, g)
 
         f = g.get_file('', 'src.c', '.c')
-        self.assertEqual(File('', 'src.c', '.c'), f)
+        self.assertIsNotNone(f)
+        self.assertEqual(f.properties['name'], 'src.c')
+        self.assertEqual(f.properties['ext'], '.c')
 
         s = g.get_struct_by_name('exp')
-        expected_s = Struct('src.c', 'exp', '', 9, 13)
-        expected_s.add_field('i', 'int')
-        expected_s.add_field('f', 'float')
-        expected_s.add_field('data', 'char[]')
-        self.assertEqual(expected_s, s)
+        self.assertIsNotNone(s)
+        self.assertEqual(s.properties['name'], 'exp')
+        self.assertEqual(s.properties['path'], 'src.c')
+        self.assertEqual(s.properties['src_start'], 9)
+        self.assertEqual(s.properties['src_end'], 13)
+        self.assertEqual(s.properties['fields'], [['i', 'int'], ['f', 'float'], ['data', 'char[]']])
 
         add = g.get_function_by_name('add')
-
-        expected_add = Function('src.c', 'add', '', 'int', '', 0, 7)
-        expected_add.add_argument('a', 'int')
-        expected_add.add_argument('b', 'int')
-        self.assertEqual(expected_add, add)
-        self.assertIn('a + b', add.src)
+        self.assertIsNotNone(add)
+        self.assertEqual(add.properties['name'], 'add')
+        self.assertEqual(add.properties['path'], 'src.c')
+        self.assertEqual(add.properties['ret_type'], 'int')
+        self.assertEqual(add.properties['src_start'], 0)
+        self.assertEqual(add.properties['src_end'], 7)
+        self.assertEqual(add.properties['args'], [['a', 'int'], ['b', 'int']])
+        self.assertIn('a + b', add.properties['src'])
 
         main = g.get_function_by_name('main')
-
-        expected_main = Function('src.c', 'main', '', 'int', '', 15, 18)
-        expected_main.add_argument('argv', 'const char**')
-        expected_main.add_argument('argc', 'int')
-        self.assertEqual(expected_main, main)
-        self.assertIn('x = add', main.src)
+        self.assertIsNotNone(main)
+        self.assertEqual(main.properties['name'], 'main')
+        self.assertEqual(main.properties['path'], 'src.c')
+        self.assertEqual(main.properties['ret_type'], 'int')
+        self.assertEqual(main.properties['src_start'], 15)
+        self.assertEqual(main.properties['src_end'], 18)
+        self.assertEqual(main.properties['args'], [['argv', 'const char**'], ['argc', 'int']])
+        self.assertIn('x = add', main.properties['src'])
 
         callees = g.function_calls(main.id)
         self.assertEqual(len(callees), 1)
         self.assertEqual(callees[0], add)
 
         callers = g.function_called_by(add.id)
-        callers = [caller.name for caller in callers]
+        callers = [caller.properties['name'] for caller in callers]
 
         self.assertEqual(len(callers), 2)
         self.assertIn('add', callers)

--- a/tests/test_git_history.py
+++ b/tests/test_git_history.py
@@ -1,8 +1,7 @@
 import os
 import unittest
-from git import Repo
+import pygit2
 from api import (
-    Graph,
     Project,
     switch_commit
 )
@@ -30,8 +29,8 @@ class Test_Git_History(unittest.TestCase):
         repo_dir = os.path.join(current_dir, 'git_repo')
 
         # Checkout HEAD commit
-        repo = Repo(repo_dir)
-        repo.git.checkout("HEAD")
+        repo = pygit2.Repository(repo_dir)
+        repo.checkout_head()
 
         proj      = Project.from_local_repository(repo_dir)
         graph     = proj.analyze_sources()
@@ -45,13 +44,13 @@ class Test_Git_History(unittest.TestCase):
         f = graph.get_file(path, name, ext)
 
         self.assertIsNotNone(f)
-        self.assertEqual(f.ext, ext)
-        self.assertEqual(f.path, path)
-        self.assertEqual(f.name, name)
+        self.assertEqual(f.properties['ext'], ext)
+        self.assertEqual(f.properties['path'], path)
+        self.assertEqual(f.properties['name'], name)
 
     def test_git_graph_structure(self):
         # validate git graph structure
-        c = repo.commit("HEAD")
+        c = repo.revparse_single("HEAD")
 
         while True:
             commits = git_graph.get_commits([c.short_id])
@@ -62,13 +61,13 @@ class Test_Git_History(unittest.TestCase):
             self.assertEqual(c.short_id,       actual['hash'])
             self.assertEqual(c.message,        actual['message'])
             self.assertEqual(c.author.name,    actual['author'])
-            self.assertEqual(c.committed_date, actual['date'])
+            self.assertEqual(c.commit_time,    actual['date'])
 
             # Advance to previous commit
-            if len(c.parents) == 0:
+            if len(c.parent_ids) == 0:
                 break
 
-            c = c.parents[0]
+            c = repo.get(c.parent_ids[0])
 
     def test_git_transitions(self):
         # our test git repo:

--- a/tests/test_graph_ops.py
+++ b/tests/test_graph_ops.py
@@ -1,7 +1,8 @@
 import unittest
+from pathlib import Path
 from falkordb import FalkorDB
-from typing import List, Optional
-from api import *
+from api import Graph
+from api.entities import File
 
 
 class TestGraphOps(unittest.TestCase):
@@ -11,50 +12,60 @@ class TestGraphOps(unittest.TestCase):
         self.graph = Graph(name='test')
 
     def test_add_function(self):
-        # Create function
-        func = Function('/path/to/function', 'func', '', 'int', '', 1, 10)
-        func.add_argument('x', 'int')
-        func.add_argument('y', 'float')
-
-        self.graph.add_function(func)
-        self.assertEqual(func, self.graph.get_function(func.id))
+        func_id = self.graph.add_entity(
+            'Function', 'func', '', '/path/to/function', 1, 10,
+            {'ret_type': 'int', 'src': '', 'args': [['x', 'int'], ['y', 'float']]}
+        )
+        result = self.graph.get_function(func_id)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.properties['name'], 'func')
+        self.assertEqual(result.properties['ret_type'], 'int')
+        self.assertEqual(result.properties['args'], [['x', 'int'], ['y', 'float']])
 
     def test_add_file(self):
-        file = File('/path/to/file', 'file', 'txt')
-
+        file = File(Path('/path/to/file.txt'), None)
         self.graph.add_file(file)
-        self.assertEqual(file, self.graph.get_file('/path/to/file', 'file', 'txt'))
+        result = self.graph.get_file('/path/to/file.txt', 'file.txt', '.txt')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.properties['name'], 'file.txt')
+        self.assertEqual(result.properties['ext'], '.txt')
 
     def test_file_add_function(self):
-        file = File('/path/to/file', 'file', 'txt')
-        func = Function('/path/to/function', 'func', '', 'int', '', 1, 10)
-
+        file = File(Path('/path/to/file.txt'), None)
         self.graph.add_file(file)
-        self.graph.add_function(func)
 
-        self.graph.connect_entities("CONTAINS", file.id, func.id)
+        func_id = self.graph.add_entity(
+            'Function', 'func', '', '/path/to/function', 1, 10,
+            {'ret_type': 'int', 'src': '', 'args': []}
+        )
+
+        self.graph.connect_entities("CONTAINS", file.id, func_id)
 
         query = """MATCH (file:File)-[:CONTAINS]->(func:Function)
                    WHERE ID(func) = $func_id AND ID(file) = $file_id
                    RETURN true"""
 
-        params = {'file_id': file.id, 'func_id': func.id}
+        params = {'file_id': file.id, 'func_id': func_id}
         res = self.g.query(query, params).result_set
         self.assertTrue(res[0][0])
 
     def test_function_calls_function(self):
-        caller = Function('/path/to/function', 'func_A', '', 'int', '', 1, 10)
-        callee = Function('/path/to/function', 'func_B', '', 'int', '', 11, 21)
+        caller_id = self.graph.add_entity(
+            'Function', 'func_A', '', '/path/to/function', 1, 10,
+            {'ret_type': 'int', 'src': '', 'args': []}
+        )
+        callee_id = self.graph.add_entity(
+            'Function', 'func_B', '', '/path/to/function', 11, 21,
+            {'ret_type': 'int', 'src': '', 'args': []}
+        )
 
-        self.graph.add_function(caller)
-        self.graph.add_function(callee)
-        self.graph.function_calls_function(caller.id, callee.id, 10)
+        self.graph.function_calls_function(caller_id, callee_id, 10)
 
         query = """MATCH (caller:Function)-[:CALLS]->(callee:Function)
                WHERE ID(caller) = $caller_id AND ID(callee) = $callee_id
                RETURN true"""
 
-        params = {'caller_id': caller.id, 'callee_id': callee.id}
+        params = {'caller_id': caller_id, 'callee_id': callee_id}
         res = self.g.query(query, params).result_set
         self.assertTrue(res[0][0])
 

--- a/tests/test_py_analyzer.py
+++ b/tests/test_py_analyzer.py
@@ -2,7 +2,8 @@ import os
 import unittest
 from pathlib import Path
 
-from api import SourceAnalyzer, File, Class, Function, Graph
+from api import SourceAnalyzer, Graph
+
 
 class Test_PY_Analyzer(unittest.TestCase):
     def test_analyzer(self):
@@ -15,7 +16,7 @@ class Test_PY_Analyzer(unittest.TestCase):
         # Get the directory of the current file
         current_dir = os.path.dirname(current_file_path)
 
-        # Append 'source_files/c' to the current directory
+        # Append 'source_files/py' to the current directory
         path = os.path.join(current_dir, 'source_files')
         path = os.path.join(path, 'py')
         path = str(path)
@@ -24,29 +25,42 @@ class Test_PY_Analyzer(unittest.TestCase):
         analyzer.analyze_local_folder(path, g)
 
         f = g.get_file('', 'src.py', '.py')
-        self.assertEqual(File('', 'src.py', '.py'), f)
+        self.assertIsNotNone(f)
+        self.assertEqual(f.properties['name'], 'src.py')
+        self.assertEqual(f.properties['ext'], '.py')
 
         log = g.get_function_by_name('log')
-        expected_log = Function('src.py', 'log', None, 'None', '', 0, 1)
-        expected_log.add_argument('msg', 'str')
-        self.assertEqual(expected_log, log)
+        self.assertIsNotNone(log)
+        self.assertEqual(log.properties['name'], 'log')
+        self.assertEqual(log.properties['path'], 'src.py')
+        self.assertEqual(log.properties['ret_type'], 'None')
+        self.assertEqual(log.properties['src_start'], 0)
+        self.assertEqual(log.properties['src_end'], 1)
+        self.assertEqual(log.properties['args'], [['msg', 'str']])
 
         abort = g.get_function_by_name('abort')
-        expected_abort = Function('src.py', 'abort', None, 'Task', '', 9, 11)
-        expected_abort.add_argument('self', 'Unknown')
-        expected_abort.add_argument('delay', 'float')
-        self.assertEqual(expected_abort, abort)
+        self.assertIsNotNone(abort)
+        self.assertEqual(abort.properties['name'], 'abort')
+        self.assertEqual(abort.properties['path'], 'src.py')
+        self.assertEqual(abort.properties['ret_type'], 'Task')
+        self.assertEqual(abort.properties['src_start'], 9)
+        self.assertEqual(abort.properties['src_end'], 11)
+        self.assertEqual(abort.properties['args'], [['self', 'Unknown'], ['delay', 'float']])
 
         init = g.get_function_by_name('__init__')
-        expected_init = Function('src.py', '__init__', None, None, '', 4, 7)
-        expected_init.add_argument('self', 'Unknown')
-        expected_init.add_argument('name', 'str')
-        expected_init.add_argument('duration', 'int')
-        self.assertEqual(expected_init, init)
+        self.assertIsNotNone(init)
+        self.assertEqual(init.properties['name'], '__init__')
+        self.assertEqual(init.properties['path'], 'src.py')
+        self.assertEqual(init.properties['src_start'], 4)
+        self.assertEqual(init.properties['src_end'], 7)
+        self.assertEqual(init.properties['args'], [['self', 'Unknown'], ['name', 'str'], ['duration', 'int']])
 
         task = g.get_class_by_name('Task')
-        expected_task = Class('src.py', 'Task', None, 3, 11)
-        self.assertEqual(expected_task, task)
+        self.assertIsNotNone(task)
+        self.assertEqual(task.properties['name'], 'Task')
+        self.assertEqual(task.properties['path'], 'src.py')
+        self.assertEqual(task.properties['src_start'], 3)
+        self.assertEqual(task.properties['src_end'], 11)
 
         callees = g.function_calls(abort.id)
         self.assertEqual(len(callees), 1)
@@ -54,7 +68,7 @@ class Test_PY_Analyzer(unittest.TestCase):
 
         print_func = g.get_function_by_name('print')
         callers = g.function_called_by(print_func.id)
-        callers = [caller.name for caller in callers]
+        callers = [caller.properties['name'] for caller in callers]
 
         self.assertIn('__init__', callers)
         self.assertIn('log', callers)


### PR DESCRIPTION
## Summary
Fix 3 test collection errors caused by importing deleted entity classes (`Struct`, `Class`, `Function`) and using GitPython instead of pygit2.

## Changes
- **test_c_analyzer.py**: Replace `Struct`/`Function` imports with FalkorDB Node property comparisons
- **test_py_analyzer.py**: Replace `Class`/`Function` imports with FalkorDB Node property comparisons
- **test_git_history.py**: Replace `from git import Repo` (GitPython) with `pygit2.Repository`
- **test_graph_ops.py**: Use `add_entity()` and Node properties instead of deleted classes
- **api/graph.py**: Fix `get_file()` to return `Node` (was calling deleted `File(path, name, ext)` constructor)

## Testing
- `pytest --collect-only` now collects all 28 tests (was 3 errors blocking all tests)
- Unit tests pass, lint passes on changed files
- Integration tests (analyzer, git history, graph ops) require FalkorDB — verified collection only

## Memory / Performance Impact
N/A

## Related Issues
Entity classes were removed in commit 19231c7 but tests were not updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined graph data retrieval to return core entity objects directly
  * Updated test infrastructure with enhanced property-based validation patterns
  * Modernized git integration dependencies for improved compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->