### PR TITLE
bench: fix find_symbol exact-match against nested properties.name

### DIFF
--- a/bench/agents/code_graph_adapter.py
+++ b/bench/agents/code_graph_adapter.py
@@ -102,15 +102,24 @@ class CodeGraphClient:
 
         auto_complete returns prefix matches; the agent often wants exact
         matches. Doing this client-side keeps the FastAPI surface untouched.
+
+        The auto_complete payload nests the symbol name under
+        `item["properties"]["name"]` (FalkorDB node properties), so we look
+        there first and only fall back to a top-level `name` for older /
+        flatter shapes the tests may pass in.
         """
         payload = self.auto_complete(repo, name)
         results = payload.get("completions") or payload.get("results") or payload
         if isinstance(results, dict):
             results = results.get("items", [])
-        return [
-            item for item in (results or [])
-            if isinstance(item, dict) and item.get("name") == name
-        ]
+        out: list[dict[str, Any]] = []
+        for item in (results or []):
+            if not isinstance(item, dict):
+                continue
+            props = item.get("properties") if isinstance(item.get("properties"), dict) else {}
+            if props.get("name") == name or item.get("name") == name:
+                out.append(item)
+        return out
 
     def note_edit(self, repo: str, path: str) -> dict[str, Any]:
         """Tell code-graph the agent just edited `path`; trigger an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ bench = [
 markers = [
     "slow: marks tests that spawn external subprocesses (LSP servers, FalkorDB, etc.); skip with -m 'not slow'",
 ]
+# Keep pytest from walking into per-instance bench worktrees that contain
+# their own copies of pytest source — collecting from those breaks the
+# host pytest's AST rewriter.
+norecursedirs = ["bench/cache", ".venv", "node_modules", "build", "dist", "*.egg-info"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_bench_code_graph_adapter.py
+++ b/tests/test_bench_code_graph_adapter.py
@@ -80,6 +80,26 @@ def test_find_symbol_filters_for_exact_match():
     assert all(item["name"] == "Foo" for item in out)
 
 
+def test_find_symbol_reads_nested_properties_name():
+    # Regression: the real /api/auto_complete payload nests `name` under
+    # `properties` (FalkorDB node properties). Before this fix every
+    # exact-name lookup returned [], so the agent fell back to bash grep.
+    resp = httpx.Response(
+        200,
+        json={"completions": [
+            {"id": 1, "labels": ["Function"],
+             "properties": {"name": "FooBar", "path": "/a.py"}},
+            {"id": 2, "labels": ["Function"],
+             "properties": {"name": "Foo", "path": "/b.py"}},
+            {"id": 3, "labels": ["Function"],
+             "properties": {"name": "Foo", "path": "/c.py"}},
+        ]},
+    )
+    with _client_with({"POST /api/auto_complete": resp}) as c:
+        out = c.find_symbol("r", "Foo")
+    assert [item["id"] for item in out] == [2, 3]
+
+
 def test_note_edit_calls_analyze_folder_and_reports_path():
     resp = httpx.Response(200, json={"status": "ok"})
     with _client_with({"POST /api/analyze_folder": resp}) as c:


### PR DESCRIPTION
## Problem

`bench/agents/code_graph_adapter.py::find_symbol` always returned `[]` for exact-name lookups against the live `/api/auto_complete` endpoint, because it filtered on a top-level `name` field that doesn't exist in the real response payload.

The real `/api/auto_complete` payload returns FalkorDB node shape:

```json
{ "id": ..., "labels": [...], "properties": { "name": "...", "path": "...", "doc": "...", ... } }
```

The adapter was filtering `item.get("name") == name`, which never matched.

## Fix

Filter checks `item["properties"]["name"]` first, then falls back to top-level `name` (for backward compat with older unit-test fixtures).

## Verification

- Regression test added: `test_find_symbol_reads_nested_properties_name`
- All 56 bench tests pass
- Live API test: `cg find-symbol --name getmodpath` now returns the function record with path + line range, where before it returned an empty list

## Notes

- Fix is in the bench adapter only — the upstream `/api/auto_complete` endpoint is unaffected
- Base branch is `dvirdukhan/benchmark-plan` because the affected file only exists there (benchmark suite not yet merged to staging)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>