### PR TITLE
feat(mcp): hybrid search_code + get_neighbors + get_file_neighbors

### DIFF
--- a/api/mcp/tools/structural.py
+++ b/api/mcp/tools/structural.py
@@ -22,7 +22,8 @@ import logging
 import math
 import os
 import re
-from collections import Counter, defaultdict
+from collections import Counter, OrderedDict, defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
@@ -165,26 +166,192 @@ async def _hybrid_rank(g, query: str, project: Optional[str]) -> list[dict[str, 
 
 
 async def _hybrid_components(g, query: str, project: Optional[str]):
-    """Fetch graph data and build per-file, weight-independent components.
+    """Build the per-file, weight-independent components for ``query``.
 
     Returns ``(files, comps, rep, abs_of, file_id_of)`` where ``comps[f]`` holds
     the min-max-normalized ``name``/``path``/``bm25``/``cent`` scores plus the
     ``pen`` penalty, and ``file_id_of[f]`` is the File node id (handle the agent
     feeds to ``get_file_neighbors``). Separated from weighting so weight sweeps
     reuse the exact same normalized inputs as the live ranker.
+
+    The expensive, query-INDEPENDENT half (three full-graph reads + tokenization)
+    is built once by :func:`_build_corpus` and cached per ``(graph, project)``;
+    only the cheap per-query overlay (:func:`_overlay`) runs on every call. See
+    the corpus-cache block below for the latency rationale and invalidation.
+    """
+    corpus = await _get_corpus(g, project)
+    return _overlay(corpus, query)
+
+
+# ---------------------------------------------------------------------------
+# Corpus cache (search_code hot path)
+# ---------------------------------------------------------------------------
+# ``search_code`` is the agent's most-called tool. Its ranker used to run three
+# full-graph Cypher reads (every File, every Function/Class incl. ``n.doc``,
+# every cross-file edge) and rebuild the BM25 corpus in Python on EVERY call.
+# Measured latency scales ~linearly with graph size (77ms @2.3K nodes, 320ms
+# @12K, ~1s extrapolated to a 41K-symbol repo), so on large repos that read +
+# rebuild dominated harness wall-time (PR #701 review).
+#
+# Everything :func:`_build_corpus` produces is query-INDEPENDENT, so we cache it
+# per ``(graph_name, project)`` and let :func:`_overlay` apply the cheap
+# per-query scoring. Invalidation is two-layered:
+#   * Explicit: ``reset_corpus_cache(graph_name)`` from ``index_repo`` after a
+#     (re)index -- covers the in-process writer.
+#   * Implicit: a ``(node_count, edge_count, commit)`` signature probe on every
+#     hit (~1ms; FalkorDB ``count()`` is O(1) metadata, the commit marker is a
+#     single Redis HGET). Covers cross-process mutation -- notably the web API's
+#     ``/api/switch_commit``, which rewrites the Redis commit marker even when
+#     node/edge counts are preserved. A rebuild whose graph mutates mid-build,
+#     or that races an explicit reset, is detected (pre/post sig + generation
+#     check) and served WITHOUT being cached, so a torn snapshot never persists.
+
+
+@dataclass
+class _Corpus:
+    """Cached, query-independent search corpus for one ``(graph, project)``."""
+
+    files: list[str]
+    abs_of: dict[str, str]
+    file_id_of: dict[str, Any]
+    pathtok: dict[str, list[str]]
+    bodytok: dict[str, list[str]]
+    # name-bearing symbols per file: (name, name_lower, src_start, src_end).
+    sym_by_file: dict[str, list[tuple[str, str, Any, Any]]]
+    n_cent: dict[str, float]  # min-max centrality (query-independent)
+    sig: tuple = field(default_factory=tuple)
+
+
+_CORPUS_CACHE: "OrderedDict[tuple, _Corpus]" = OrderedDict()
+_CORPUS_LOCKS: dict[tuple, asyncio.Lock] = {}
+_CORPUS_GEN: dict[str, int] = defaultdict(int)
+_CORPUS_META_LOCK = asyncio.Lock()  # guards lazy per-key lock creation
+_REDIS_MARKER_CLIENT: Any = None  # lazily created, reused (connection pool)
+
+
+def _corpus_cache_max() -> int:
+    """Max number of corpora to retain (LRU). Each holds a full token corpus."""
+    try:
+        return max(1, int(os.getenv("CODE_GRAPH_SEARCH_CACHE_MAX", "8")))
+    except ValueError:
+        return 8
+
+
+def _commit_marker(project: Optional[str], branch: Optional[str]) -> Optional[str]:
+    """Best-effort, quiet read of the recorded commit for ``(project, branch)``.
+
+    Folded into the corpus signature so a cross-process ``switch_commit`` /
+    reindex (which rewrites the Redis commit marker) invalidates the cache even
+    when node/edge counts happen to be preserved. Any failure -> ``None`` (the
+    signature degrades to counts-only and never raises into ``search_code``).
+    Reads Redis directly rather than via ``get_repo_commit`` so a missing marker
+    (non-git folder) doesn't log a warning on every probe.
+    """
+    global _REDIS_MARKER_CLIENT
+    if not project:
+        return None
+    try:
+        from api.info import _repo_info_key, get_redis_connection
+
+        if _REDIS_MARKER_CLIENT is None:
+            _REDIS_MARKER_CLIENT = get_redis_connection()
+        return _REDIS_MARKER_CLIENT.hget(_repo_info_key(project, branch), "commit")
+    except Exception:
+        return None
+
+
+async def _graph_sig(g, project: Optional[str]) -> tuple:
+    """Cheap (~1ms) cache-validity signature for the graph behind ``g``.
+
+    On any probe failure returns a never-equal sentinel so the caller rebuilds
+    (degrading to the always-fresh status quo) rather than serving a stale hit.
+    """
+    try:
+        n = (await g._query("MATCH (n) RETURN count(n)")).result_set[0][0]
+        e = (await g._query("MATCH ()-[r]->() RETURN count(r)")).result_set[0][0]
+    except Exception:
+        return (None, None, object())
+    commit = _commit_marker(project, getattr(g, "branch", None))
+    return (int(n or 0), int(e or 0), commit)
+
+
+async def _corpus_lock(key: tuple) -> asyncio.Lock:
+    async with _CORPUS_META_LOCK:
+        lock = _CORPUS_LOCKS.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _CORPUS_LOCKS[key] = lock
+        return lock
+
+
+def reset_corpus_cache(graph_name: Optional[str] = None) -> None:
+    """Invalidate cached search corpora.
+
+    Called by ``index_repo`` after a (re)index so the next ``search_code``
+    rebuilds. ``graph_name`` ``None`` clears everything; otherwise clears
+    entries for that graph identity. Bumps a per-graph generation counter so a
+    rebuild that started before the reset won't store its now-stale corpus.
+    """
+    if graph_name is None:
+        _CORPUS_CACHE.clear()
+        for gname in list(_CORPUS_GEN.keys()):
+            _CORPUS_GEN[gname] += 1
+        return
+    for key in [k for k in _CORPUS_CACHE if k[0] == graph_name]:
+        del _CORPUS_CACHE[key]
+    _CORPUS_GEN[graph_name] += 1
+
+
+async def _get_corpus(g, project: Optional[str]) -> _Corpus:
+    """Return a cached corpus for ``(g, project)`` or build (and maybe cache) one."""
+    key = (g.name, project)
+    sig = await _graph_sig(g, project)
+    ent = _CORPUS_CACHE.get(key)
+    if ent is not None and ent.sig == sig:
+        _CORPUS_CACHE.move_to_end(key)
+        return ent
+
+    lock = await _corpus_lock(key)
+    async with lock:
+        # Re-check: another coroutine may have rebuilt while we waited.
+        sig_before = await _graph_sig(g, project)
+        ent = _CORPUS_CACHE.get(key)
+        if ent is not None and ent.sig == sig_before:
+            _CORPUS_CACHE.move_to_end(key)
+            return ent
+
+        gen_before = _CORPUS_GEN[g.name]
+        corpus = await _build_corpus(g, project)
+        sig_after = await _graph_sig(g, project)
+        corpus.sig = sig_after
+
+        # Only cache a corpus that is internally consistent (the graph did not
+        # change across the reads) and was not invalidated by a reset mid-build.
+        stable = sig_after == sig_before and _CORPUS_GEN[g.name] == gen_before
+        if stable:
+            _CORPUS_CACHE[key] = corpus
+            _CORPUS_CACHE.move_to_end(key)
+            while len(_CORPUS_CACHE) > _corpus_cache_max():
+                _CORPUS_CACHE.popitem(last=False)
+        return corpus
+
+
+async def _build_corpus(g, project: Optional[str]) -> _Corpus:
+    """Run the three graph reads + tokenization (the query-independent half).
+
+    Mirrors the original ``_hybrid_components`` read/build logic exactly, minus
+    the query-dependent ``name_exact``/``rep`` selection (moved to
+    :func:`_overlay`). ``bodytok`` (path + symbol-name subtokens + capped doc
+    tokens) and ``centrality`` are query-independent and built identically here.
     """
     def rel(p: Optional[str]) -> str:
         return _relativize(p, project) if p else ""
-
-    qtok = set(_tokenize(query))
-    qids = _issue_identifiers(query)
 
     pathtok: dict[str, list[str]] = {}
     bodytok: dict[str, list[str]] = defaultdict(list)
     abs_of: dict[str, str] = {}
     file_id_of: dict[str, Any] = {}
-    name_exact: dict[str, float] = defaultdict(float)
-    rep: dict[str, dict[str, Any]] = {}
+    sym_by_file: dict[str, list[tuple[str, str, Any, Any]]] = defaultdict(list)
 
     files_res = await g._query("MATCH (f:File) RETURN f.path, ID(f)")
     for row in files_res.result_set:
@@ -214,19 +381,9 @@ async def _hybrid_components(g, query: str, project: Optional[str]):
             continue
         if name:
             bodytok[rp].extend(_subtokens(name))
-            is_exact = name.lower() in qids
-            if is_exact:
-                name_exact[rp] += 1.0
-            # Representative symbol for the file's snippet: prefer one whose name
-            # exactly matches a query identifier, otherwise the lowest-``src_start``
-            # symbol. Fully deterministic regardless of result-set order via a
-            # stable sort key (exact first, then src_start, then name, then
-            # src_end) so ties / missing ``src_start`` never depend on row order.
-            cand = {"name": name, "src_start": start, "src_end": end,
-                    "exact": is_exact}
-            cur = rep.get(rp)
-            if cur is None or _rep_key(cand) < _rep_key(cur):
-                rep[rp] = cand
+            # Record name-bearing symbols so _overlay can recompute name_exact
+            # and the representative symbol against the (query-dependent) ids.
+            sym_by_file[rp].append((name, name.lower(), start, end))
         if doc and body_used[rp] < _HYBRID_BODY_TOKEN_CAP:
             toks = _tokenize(doc)[: _HYBRID_BODY_TOKEN_CAP - body_used[rp]]
             bodytok[rp].extend(toks)
@@ -242,15 +399,63 @@ async def _hybrid_components(g, query: str, project: Optional[str]):
         centrality[rel(bpath)] += math.log1p(int(deg or 0))
 
     files = sorted(abs_of)
+    n_cent = (
+        _minmax({f: centrality.get(f, 0.0) for f in files}) if files else {}
+    )
+
+    return _Corpus(
+        files=files,
+        abs_of=dict(abs_of),
+        file_id_of=dict(file_id_of),
+        pathtok=dict(pathtok),
+        bodytok=dict(bodytok),
+        sym_by_file=dict(sym_by_file),
+        n_cent=n_cent,
+    )
+
+
+def _overlay(corpus: _Corpus, query: str):
+    """Apply the cheap, query-dependent scoring over a cached corpus.
+
+    Reproduces the original ``_hybrid_components`` output exactly: name-exact
+    counts and the representative symbol come from ``corpus.sym_by_file`` (the
+    ``_rep_key`` ordering is row-order independent), BM25 and path overlap run
+    over the cached corpus, and the ``n_name`` normalization preserves the
+    original ``name_exact if name_exact else zeros`` quirk.
+    """
+    files = corpus.files
     if not files:
         return [], {}, {}, {}, {}
 
-    path_overlap = {f: float(len(qtok & set(pathtok.get(f, [])))) for f in files}
-    raw_bm25 = _bm25(qtok, files, bodytok)
+    qtok = set(_tokenize(query))
+    qids = _issue_identifiers(query)
+
+    name_exact: dict[str, float] = defaultdict(float)
+    rep: dict[str, dict[str, Any]] = {}
+    for f, syms in corpus.sym_by_file.items():
+        best: Optional[dict[str, Any]] = None
+        cnt = 0.0
+        for (name, name_lower, start, end) in syms:
+            is_exact = name_lower in qids
+            if is_exact:
+                cnt += 1.0
+            cand = {"name": name, "src_start": start, "src_end": end,
+                    "exact": is_exact}
+            if best is None or _rep_key(cand) < _rep_key(best):
+                best = cand
+        if cnt:
+            name_exact[f] = cnt
+        if best is not None:
+            rep[f] = best
+
+    path_overlap = {
+        f: float(len(qtok & set(corpus.pathtok.get(f, [])))) for f in files
+    }
+    raw_bm25 = _bm25(qtok, files, corpus.bodytok)
     n_name = _minmax(name_exact if name_exact else {f: 0.0 for f in files})
     n_path = _minmax(path_overlap)
     n_bm25 = _minmax(raw_bm25)
-    n_cent = _minmax({f: centrality.get(f, 0.0) for f in files})
+    n_cent = corpus.n_cent
 
     comps: dict[str, dict[str, float]] = {}
     for f in files:
@@ -261,15 +466,15 @@ async def _hybrid_components(g, query: str, project: Optional[str]):
             "cent": n_cent.get(f, 0.0),
             "pen": _HYBRID_W_PEN if _PENALTY_RE.search(f) else 0.0,
             # Raw (un-normalized) query-dependent signal. A file with zero
-            # lexical overlap (name/path/body) is not relevant to the query —
-            # only query-independent centrality could rank it — so search_code
+            # lexical overlap (name/path/body) is not relevant to the query --
+            # only query-independent centrality could rank it -- so search_code
             # drops it rather than returning noise for an unmatched query.
             "lex": (name_exact.get(f, 0.0)
                     + path_overlap.get(f, 0.0)
                     + raw_bm25.get(f, 0.0)),
         }
 
-    return files, comps, rep, abs_of, file_id_of
+    return files, comps, rep, corpus.abs_of, corpus.file_id_of
 
 
 def _hybrid_score(
@@ -488,7 +693,12 @@ async def index_repo(
             "mode": "full",
         }
 
-    return await loop.run_in_executor(None, _do_index)
+    result = await loop.run_in_executor(None, _do_index)
+    # A (re)index invalidates any cached search corpus for this graph so the
+    # next search_code rebuilds against the new contents (covers the in-process
+    # writer; cross-process mutation is caught by the signature probe).
+    reset_corpus_cache(result.get("graph_name"))
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/api/mcp/tools/structural.py
+++ b/api/mcp/tools/structural.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 import re
+from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any, Optional
 
@@ -28,6 +30,250 @@ from ..server import app
 
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Hybrid ranking (search_code Step 3) — tunable weights
+# ---------------------------------------------------------------------------
+# Repo-wide file relevance = weighted sum of normalized component scores minus
+# a path penalty. Each component is min-max normalized across files so the
+# weights are directly comparable. Tune these after the smoke test.
+_HYBRID_W_NAME = 2.0   # symbol name == a query identifier (exact)
+_HYBRID_W_PATH = 1.5   # query tokens present in the file's path
+_HYBRID_W_BM25 = 1.5   # BM25 over file body (symbol names + docstrings + path)
+_HYBRID_W_CENT = 0.5   # log(1 + cross-file in-degree): structural centrality
+_HYBRID_W_PEN = 1.0    # penalty for test/legacy/vendored/etc. paths
+_HYBRID_BODY_TOKEN_CAP = 4000
+_HYBRID_MIN_IDENT_LEN = 4
+_HYBRID_BM25_K1 = 1.5
+_HYBRID_BM25_B = 0.75
+
+_WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_CAMEL_RE = re.compile(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z0-9]+|[A-Z]+")
+_PENALTY_RE = re.compile(
+    r"(^|/)(tests?|testing|conftest|migrations?|legacy|vendor|vendored|"
+    r"third_party|__pycache__|examples?|docs?|benchmarks?)(/|$)|_test\.py$|(^|/)test_",
+    re.IGNORECASE,
+)
+
+
+def _subtokens(ident: str) -> list[str]:
+    """Split an identifier into snake/camel sub-tokens (lowercased) plus itself."""
+    out: list[str] = []
+    for part in ident.split("_"):
+        if not part:
+            continue
+        out.extend(m.group(0).lower() for m in _CAMEL_RE.finditer(part))
+    out.append(ident.lower())
+    return [t for t in out if t]
+
+
+def _tokenize(text: str) -> list[str]:
+    toks: list[str] = []
+    for m in _WORD_RE.finditer(text or ""):
+        toks.extend(_subtokens(m.group(0)))
+    return toks
+
+
+def _issue_identifiers(text: str) -> set[str]:
+    """Candidate symbol names mentioned in the query (backticked or code-shaped)."""
+    cands: set[str] = set()
+    for m in re.finditer(r"`([^`]+)`", text or ""):
+        for ident in _WORD_RE.findall(m.group(1)):
+            if len(ident) >= _HYBRID_MIN_IDENT_LEN:
+                cands.add(ident.lower())
+    for ident in _WORD_RE.findall(text or ""):
+        if len(ident) >= _HYBRID_MIN_IDENT_LEN and (
+            "_" in ident or re.search(r"[a-z][A-Z]", ident) or ident[0].isupper()
+        ):
+            cands.add(ident.lower())
+    return cands
+
+
+def _minmax(d: dict[str, float]) -> dict[str, float]:
+    if not d:
+        return {}
+    vals = list(d.values())
+    lo, hi = min(vals), max(vals)
+    if hi - lo < 1e-12:
+        return {k: 0.0 for k in d}
+    return {k: (v - lo) / (hi - lo) for k, v in d.items()}
+
+
+def _bm25(query_tokens: set[str], files: list[str],
+          tokmap: dict[str, list[str]]) -> dict[str, float]:
+    docs = [tokmap.get(f, []) for f in files]
+    n = len(docs)
+    if n == 0:
+        return {}
+    df: Counter = Counter()
+    for d in docs:
+        for t in set(d):
+            df[t] += 1
+    avgdl = (sum(len(d) for d in docs) / n) or 1.0
+    idf = {t: math.log(1 + (n - k + 0.5) / (k + 0.5)) for t, k in df.items()}
+    k1, b = _HYBRID_BM25_K1, _HYBRID_BM25_B
+    out: dict[str, float] = {}
+    for f, d in zip(files, docs):
+        if not d:
+            out[f] = 0.0
+            continue
+        tf = Counter(d)
+        dl = len(d)
+        s = 0.0
+        for t in query_tokens:
+            freq = tf.get(t)
+            if not freq:
+                continue
+            s += idf.get(t, 0.0) * (freq * (k1 + 1)) / (
+                freq + k1 * (1 - b + b * dl / avgdl)
+            )
+        out[f] = s
+    return out
+
+
+async def _hybrid_rank(g, query: str, project: Optional[str]) -> list[dict[str, Any]]:
+    """Rank every indexed file by relevance to a free-text ``query``.
+
+    Runs three aggregate Cypher reads (files, symbols, cross-file edge degree),
+    scores files with the weighted hybrid above, and returns an ordered list of
+    ``{abs_path, file, score, name, src_start, src_end}`` (best representative
+    symbol per file, used for the snippet). Pure read; no graph mutation.
+    """
+    files, comps, rep, abs_of, file_id_of = await _hybrid_components(g, query, project)
+    return _hybrid_score(files, comps, rep, abs_of, file_id_of)
+
+
+async def _hybrid_components(g, query: str, project: Optional[str]):
+    """Fetch graph data and build per-file, weight-independent components.
+
+    Returns ``(files, comps, rep, abs_of, file_id_of)`` where ``comps[f]`` holds
+    the min-max-normalized ``name``/``path``/``bm25``/``cent`` scores plus the
+    ``pen`` penalty, and ``file_id_of[f]`` is the File node id (handle the agent
+    feeds to ``get_file_neighbors``). Separated from weighting so weight sweeps
+    reuse the exact same normalized inputs as the live ranker.
+    """
+    def rel(p: Optional[str]) -> str:
+        return _relativize(p, project) if p else ""
+
+    qtok = set(_tokenize(query))
+    qids = _issue_identifiers(query)
+
+    pathtok: dict[str, list[str]] = {}
+    bodytok: dict[str, list[str]] = defaultdict(list)
+    abs_of: dict[str, str] = {}
+    file_id_of: dict[str, Any] = {}
+    name_exact: dict[str, float] = defaultdict(float)
+    rep: dict[str, dict[str, Any]] = {}
+
+    files_res = await g._query("MATCH (f:File) RETURN f.path, ID(f)")
+    for row in files_res.result_set:
+        ap = row[0]
+        if not ap:
+            continue
+        rp = rel(ap)
+        abs_of[rp] = ap
+        file_id_of[rp] = row[1]
+        pt = _tokenize(rp.replace("/", " "))
+        pathtok[rp] = pt
+        bodytok[rp].extend(pt)
+
+    sym_res = await g._query(
+        "MATCH (n) WHERE n:Function OR n:Class "
+        "RETURN n.name, n.path, n.doc, n.src_start, n.src_end"
+    )
+    body_used: Counter = Counter()
+    for name, path, doc, start, end in sym_res.result_set:
+        if not path:
+            continue
+        rp = rel(path)
+        # Rank only over real ``File`` nodes; symbols whose containing file was
+        # not emitted as a File node would otherwise inflate the BM25 corpus and
+        # skew min-max normalization.
+        if rp not in abs_of:
+            continue
+        if name:
+            bodytok[rp].extend(_subtokens(name))
+            if name.lower() in qids:
+                name_exact[rp] += 1.0
+                rep.setdefault(rp, {"name": name, "src_start": start, "src_end": end})
+        if rp not in rep and name:
+            cur = rep.get(rp)
+            if cur is None or (start is not None and (
+                cur.get("src_start") is None or start < cur["src_start"])):
+                rep[rp] = {"name": name, "src_start": start, "src_end": end}
+        if doc and body_used[rp] < _HYBRID_BODY_TOKEN_CAP:
+            toks = _tokenize(doc)[: _HYBRID_BODY_TOKEN_CAP - body_used[rp]]
+            bodytok[rp].extend(toks)
+            body_used[rp] += len(toks)
+
+    deg_res = await g._query(
+        "MATCH (a)-[:CALLS|IMPORTS|EXTENDS|OVERRIDES]->(b) "
+        "WHERE a.path IS NOT NULL AND b.path IS NOT NULL AND a.path <> b.path "
+        "RETURN b.path AS p, count(*) AS deg"
+    )
+    centrality: dict[str, float] = defaultdict(float)
+    for bpath, deg in deg_res.result_set:
+        centrality[rel(bpath)] += math.log1p(int(deg or 0))
+
+    files = sorted(abs_of)
+    if not files:
+        return [], {}, {}, {}, {}
+
+    path_overlap = {f: float(len(qtok & set(pathtok.get(f, [])))) for f in files}
+    n_name = _minmax(name_exact if name_exact else {f: 0.0 for f in files})
+    n_path = _minmax(path_overlap)
+    n_bm25 = _minmax(_bm25(qtok, files, bodytok))
+    n_cent = _minmax({f: centrality.get(f, 0.0) for f in files})
+
+    comps: dict[str, dict[str, float]] = {}
+    for f in files:
+        comps[f] = {
+            "name": n_name.get(f, 0.0),
+            "path": n_path.get(f, 0.0),
+            "bm25": n_bm25.get(f, 0.0),
+            "cent": n_cent.get(f, 0.0),
+            "pen": _HYBRID_W_PEN if _PENALTY_RE.search(f) else 0.0,
+        }
+
+    return files, comps, rep, abs_of, file_id_of
+
+
+def _hybrid_score(
+    files: list[str],
+    comps: dict[str, dict[str, float]],
+    rep: dict[str, dict[str, Any]],
+    abs_of: dict[str, str],
+    file_id_of: Optional[dict[str, Any]] = None,
+) -> list[dict[str, Any]]:
+    """Apply the hybrid weights to pre-normalized per-file components.
+
+    Split out from ``_hybrid_rank`` so the weighting can be exercised
+    independently of the (expensive) graph reads and normalization.
+    """
+    file_id_of = file_id_of or {}
+    scored: list[dict[str, Any]] = []
+    for f in files:
+        c = comps[f]
+        score = (
+            _HYBRID_W_NAME * c["name"]
+            + _HYBRID_W_PATH * c["path"]
+            + _HYBRID_W_BM25 * c["bm25"]
+            + _HYBRID_W_CENT * c["cent"]
+            - c["pen"]
+        )
+        r = rep.get(f, {})
+        scored.append({
+            "abs_path": abs_of[f],
+            "file": f,
+            "file_id": file_id_of.get(f),
+            "score": round(score, 4),
+            "name": r.get("name"),
+            "src_start": r.get("src_start"),
+            "src_end": r.get("src_end"),
+        })
+    scored.sort(key=lambda d: -d["score"])
+    return scored
 
 
 # ---------------------------------------------------------------------------
@@ -223,13 +469,118 @@ def _project_arg(project: str, branch: Optional[str]):
     return AsyncGraphQuery(project, branch=branch)
 
 
-def _node_summary(n: Any) -> dict[str, Any]:
+def _relativize(path: Optional[str], rel_to: Optional[str]) -> Optional[str]:
+    """Strip the indexing-root prefix so file paths are repo-relative.
+
+    Stored paths are absolute and include the worktree root whose final
+    segment equals the ``project`` identifier
+    (e.g. ``/<root>/<project>/pkg/mod.py``). We strip up to and including the
+    FIRST ``/<project>/`` occurrence so the result is the repo-relative path.
+    ``find`` (first match) is deliberate: a nested directory may legitimately
+    repeat the project name and must be preserved in the relative path.
+
+    Absolute worktree prefixes are ~150 chars/row of pure noise that the agent
+    re-reads on every cached turn; relativizing is the cheapest token win.
+    """
+    if not path or not rel_to:
+        return path
+    marker = f"/{rel_to}/"
+    idx = path.find(marker)
+    if idx == -1:
+        return path
+    return path[idx + len(marker):]
+
+
+def _raw_name(n: Any) -> Optional[str]:
+    """Extract the ``name`` property from a Node or already-encoded dict."""
+    if hasattr(n, "properties"):
+        return (n.properties or {}).get("name")
+    return (dict(n).get("properties") or {}).get("name")
+
+
+# Snippet windows (lines) attached to results so the agent can judge relevance
+# without a follow-up full-file ``view`` — the dominant token cost. Neighbor
+# tools return small, high-relevance result sets, so they carry a real window;
+# search_code can return many name matches, so it carries only a signature.
+NEIGHBOR_SNIPPET_LINES = 12
+SEARCH_SNIPPET_LINES = 2
+_SNIPPET_LINE_CHARS = 200
+"""Per-line char cap so a single minified line cannot blow up the payload."""
+
+
+def _read_snippet(
+    abs_path: Optional[str],
+    src_start: Any,
+    src_end: Any,
+    max_lines: int,
+) -> Optional[str]:
+    """Read up to ``max_lines`` leading source lines for an entity from disk.
+
+    Paths and line numbers are stored on nodes but the source text is not, so
+    we read the file lazily. Returns the entity's leading lines (signature plus
+    the start of the body) joined by newlines, or ``None`` when the file/line
+    info is missing or unreadable. Each line is capped at
+    ``_SNIPPET_LINE_CHARS``. Carrying a snippet in the result lets a single
+    tool call replace a follow-up ``view`` of a large file.
+    """
+    if not abs_path or max_lines <= 0:
+        return None
+    try:
+        start = int(src_start)
+    except (TypeError, ValueError):
+        return None
+    if start < 1:
+        return None
+    try:
+        end = int(src_end)
+    except (TypeError, ValueError):
+        end = start
+    # Read a slightly larger window than ``max_lines`` (bounded by the entity's
+    # own extent) so leading blank / decorator-only lines can be skipped without
+    # starving the substantive output.
+    hard_end = end if end >= start else start
+    read_until = min(hard_end, start + max_lines + 5)
+    raw_lines: list[str] = []
+    try:
+        with open(abs_path, "r", encoding="utf-8", errors="replace") as fh:
+            for i, raw in enumerate(fh, start=1):
+                if i < start:
+                    continue
+                if i > read_until:
+                    break
+                raw_lines.append(raw.rstrip("\n"))
+    except OSError:
+        return None
+    # Skip leading blank / decorator-only lines so the limited window lands on
+    # the substantive signature + body rather than being wasted on a blank line
+    # or a bare ``@decorator``.
+    while raw_lines and (
+        not raw_lines[0].strip() or raw_lines[0].lstrip().startswith("@")
+    ):
+        raw_lines.pop(0)
+    lines = [ln[:_SNIPPET_LINE_CHARS] for ln in raw_lines[:max_lines]]
+    if not lines:
+        return None
+    return "\n".join(lines)
+
+
+def _node_summary(
+    n: Any,
+    rel_to: Optional[str] = None,
+    snippet_lines: int = 0,
+    with_label: bool = True,
+) -> dict[str, Any]:
     """Normalize a FalkorDB Node (or already-encoded dict) to a flat payload.
 
     ``encode_node`` returns ``{id, labels, properties: {...}}`` because Node
-    properties live on a nested attribute. Agents want a flat record, and
-    they also want a single ``label`` (the meaningful one — File, Class,
-    Function — not the fulltext-index marker ``Searchable``).
+    properties live on a nested attribute. Agents want a flat record. We keep
+    the single meaningful ``label`` (File, Class, Function — not the fulltext
+    marker ``Searchable``) only for ``search_code``, where File-vs-Function
+    disambiguation matters; neighbor/path results omit it via ``with_label``
+    since the relation already implies the type.
+
+    When ``rel_to`` is given (the project/worktree identifier), ``file`` is
+    relativized to drop the absolute worktree prefix.
     """
     if hasattr(n, "properties"):
         props = dict(n.properties or {})
@@ -242,13 +593,24 @@ def _node_summary(n: Any) -> dict[str, Any]:
         node_id = d.get("id")
 
     label = next((lbl for lbl in labels if lbl != "Searchable"), None)
-    return {
+    summary: dict[str, Any] = {
         "id": node_id,
         "name": props.get("name"),
-        "label": label,
-        "file": props.get("path"),
-        "line": props.get("src_start"),
     }
+    if with_label:
+        summary["label"] = label
+    summary["file"] = _relativize(props.get("path"), rel_to)
+    summary["line"] = props.get("src_start")
+    if snippet_lines > 0:
+        snip = _read_snippet(
+            props.get("path"),
+            props.get("src_start"),
+            props.get("src_end"),
+            snippet_lines,
+        )
+        if snip:
+            summary["snippet"] = snip
+    return summary
 
 
 # Relationship-type names are graph labels (SCREAMING_SNAKE_CASE, e.g. CALLS,
@@ -324,7 +686,12 @@ async def _neighbors_payload(
         res = await g._query(q, {"sid": node_id, "limit": int(limit)})
         out: list[dict[str, Any]] = []
         for row in res.result_set:
-            entry = _node_summary(row[0])
+            entry = _node_summary(
+                row[0],
+                rel_to=project,
+                snippet_lines=NEIGHBOR_SNIPPET_LINES,
+                with_label=False,
+            )
             entry["relation"] = row[1]
             entry["direction"] = direction
             out.append(entry)
@@ -334,13 +701,61 @@ async def _neighbors_payload(
 
 
 @app.tool(
-    name="get_callers",
+    name="get_neighbors",
     description=(
-        "Return functions that call the given symbol (incoming CALLS edges). "
-        "`symbol_id` is the integer node id returned by `search_code` or "
-        "other tools."
+        "Adjacent symbols of a SYMBOL node (Function/Class) via graph edges, by "
+        "its integer node id. Pick relation+direction: "
+        "`CALLS`+`IN`=callers (upstream co-change sites); `CALLS`+`OUT`=callees; "
+        "`IMPORTS`+`IN`=importers of a File; `OVERRIDES`+`BOTH`=polymorphic "
+        "dispatch that plain CALLS miss; `[IMPORTS,CALLS,DEFINES]`+`OUT`="
+        "dependencies. `relation` is one name or a list; `direction` is IN, OUT, "
+        "or BOTH. Each result carries a code `snippet`, so you rarely need to "
+        "`view` the file. To navigate from a `search_code` hit (a FILE), use "
+        "`get_file_neighbors` with its `file_id` instead — this tool expects a "
+        "symbol id."
     ),
 )
+async def get_neighbors(
+    symbol_id: Any,
+    project: str,
+    relation: Any = "CALLS",
+    direction: str = "OUT",
+    branch: Optional[str] = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Unified single-hop neighbor traversal (replaces the per-edge tools).
+
+    ``relation`` accepts a single edge type or a list of them; results are
+    aggregated across relations and deduped. ``direction`` is ``IN``
+    (incoming edges), ``OUT`` (outgoing), or ``BOTH`` (union of IN+OUT).
+    """
+    rels = [relation] if isinstance(relation, str) else list(relation)
+    direction = (direction or "OUT").upper()
+    if direction == "BOTH":
+        dirs = ["OUT", "IN"]
+    elif direction in ("IN", "OUT"):
+        dirs = [direction]
+    else:
+        raise ValueError(
+            f"direction must be 'IN', 'OUT', or 'BOTH', got: {direction!r}"
+        )
+
+    seen: set[Any] = set()
+    out: list[dict[str, Any]] = []
+    for d in dirs:
+        for rel in rels:
+            rows = await _neighbors_payload(project, branch, symbol_id, rel, d, limit)
+            for row in rows:
+                key = (row.get("id"), row.get("relation"), row.get("direction"))
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(row)
+                if len(out) >= limit:
+                    return out
+    return out
+
+
 async def get_callers(
     symbol_id: int | str,
     project: str,
@@ -350,12 +765,6 @@ async def get_callers(
     return await _neighbors_payload(project, branch, symbol_id, "CALLS", "IN", limit)
 
 
-@app.tool(
-    name="get_callees",
-    description=(
-        "Return functions that the given symbol calls (outgoing CALLS edges)."
-    ),
-)
 async def get_callees(
     symbol_id: int | str,
     project: str,
@@ -365,14 +774,6 @@ async def get_callees(
     return await _neighbors_payload(project, branch, symbol_id, "CALLS", "OUT", limit)
 
 
-@app.tool(
-    name="get_dependencies",
-    description=(
-        "Return outgoing neighbors of the given symbol across any of the "
-        "specified relation types (default: IMPORTS, CALLS, DEFINES). "
-        "Useful for 'what does this depend on' queries."
-    ),
-)
 async def get_dependencies(
     symbol_id: int | str,
     project: str,
@@ -406,6 +807,55 @@ async def get_dependencies(
 
 
 # ---------------------------------------------------------------------------
+# Spike 1a — get_importers (incoming IMPORTS) / get_overrides (OVERRIDES)
+# ---------------------------------------------------------------------------
+
+
+async def get_importers(
+    symbol_id: Any,
+    project: str,
+    branch: Optional[str] = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    return await _neighbors_payload(
+        project, branch, symbol_id, "IMPORTS", "IN", limit
+    )
+
+
+async def get_overrides(
+    symbol_id: Any,
+    project: str,
+    branch: Optional[str] = None,
+    direction: str = "BOTH",
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    direction = (direction or "BOTH").upper()
+    if direction in ("IN", "OUT"):
+        return await _neighbors_payload(
+            project, branch, symbol_id, "OVERRIDES", direction, limit
+        )
+    if direction != "BOTH":
+        raise ValueError(
+            f"direction must be 'IN', 'OUT', or 'BOTH', got: {direction!r}"
+        )
+    seen: set[Any] = set()
+    out: list[dict[str, Any]] = []
+    for d in ("OUT", "IN"):
+        rows = await _neighbors_payload(
+            project, branch, symbol_id, "OVERRIDES", d, limit
+        )
+        for row in rows:
+            key = (row.get("id"), row.get("direction"))
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(row)
+            if len(out) >= limit:
+                return out
+    return out
+
+
+# ---------------------------------------------------------------------------
 # T7 — find_path
 # ---------------------------------------------------------------------------
 
@@ -414,8 +864,10 @@ async def get_dependencies(
     name="find_path",
     description=(
         "Return up to `max_paths` CALLS-path sequences from `source_id` to "
-        "`dest_id`. Useful for 'how does A reach B' questions. Returns an "
-        "empty list when no path exists."
+        "`dest_id` ('how does A reach B'). Use to confirm whether a suspected "
+        "entry point actually reaches a suspected buggy function, and through "
+        "which intermediaries. Returns an empty list when no STATIC path exists "
+        "(dynamic dispatch is not captured)."
     ),
 )
 async def find_path(
@@ -441,7 +893,7 @@ async def find_path(
     paths: list[dict[str, Any]] = []
     for entry in raw:
         node_seq = [
-            _node_summary(x)
+            _node_summary(x, rel_to=project, with_label=False)
             for x in entry
             # Discriminate on ``labels``: ``encode_node`` emits a top-level
             # ``labels`` key, while ``encode_edge`` does not (edges carry
@@ -463,31 +915,224 @@ async def find_path(
 @app.tool(
     name="search_code",
     description=(
-        "Prefix-search for symbols (functions, classes, files) whose name "
-        "starts with `prefix`. Backed by FalkorDB's full-text index. The "
-        "agent typically calls this first to discover symbol ids for the "
-        "navigation tools (`get_callers`, `find_path`, ...)."
+        "Localize a bug/feature to its files from a CONCEPTUAL free-text query. "
+        "Phrase it as a natural-language description of the behavior and area "
+        "involved (e.g. 'face centroid computation uses node connectivity' or "
+        "'tagging a library entry duplicates tags') — the issue title plus a "
+        "phrase about what the code DOES. Backticked symbol/error names are fine "
+        "as seasoning, but DO NOT pass a bare list of identifiers: a pile of exact "
+        "symbol names collapses the ranking onto their single definition file and "
+        "hides the related files you didn't know to name (use grep if you already "
+        "know the exact symbol). "
+        "Ranks every indexed file by a hybrid of (exact symbol-name match, "
+        "path-token overlap, BM25 over symbol names + docstrings, and call-graph "
+        "centrality), de-prioritizing test/vendored paths. Returns the top files "
+        "as {file, file_id, score, name, line, snippet} — best candidates first, "
+        "so the usual top 3-5 are where to start. Unlike a name lookup, it "
+        "surfaces the right file even when you don't know the exact symbol. Feed a "
+        "result's `file_id` to `get_file_neighbors` to reveal the files "
+        "structurally coupled to it (imports/calls) — co-change candidates a "
+        "textual search misses."
     ),
 )
 async def search_code(
-    prefix: str,
+    query: str,
     project: str,
     branch: Optional[str] = None,
-    limit: int = 20,
+    limit: int = 10,
 ) -> list[dict[str, Any]]:
     g = _project_arg(project, branch)
     try:
-        # Push the caller's ``limit`` down to the DB so it is actually honored
-        # (the underlying full-text query is otherwise capped at its default).
-        raw = await g.prefix_search(prefix, limit=limit)
+        ranked = await _hybrid_rank(g, query, project)
     finally:
         await g.close()
-    return [_node_summary(node) for node in raw]
+    out: list[dict[str, Any]] = []
+    for r in ranked[:limit]:
+        rec: dict[str, Any] = {
+            "file": r["file"],
+            "file_id": r["file_id"],
+            "score": r["score"],
+            "name": r["name"],
+            "line": r["src_start"],
+            "label": "File",
+        }
+        snip = _read_snippet(
+            r["abs_path"],
+            r["src_start"] if r["src_start"] is not None else 1,
+            r["src_end"] if r["src_end"] is not None else r["src_start"],
+            SEARCH_SNIPPET_LINES,
+        )
+        if snip:
+            rec["snippet"] = snip
+        out.append(rec)
+    return out
 
 
 # ---------------------------------------------------------------------------
-# T6 — impact_analysis (variable-depth Cypher with DISTINCT for cycle safety)
+# T8b — get_file_neighbors (file-level structural coupling)
 # ---------------------------------------------------------------------------
+
+FILE_NEIGHBOR_RELS = ("IMPORTS", "CALLS", "EXTENDS", "OVERRIDES")
+FILE_NEIGHBOR_MAX = 100
+"""Hard cap on returned neighbor files. The default is intentionally high:
+the value of this tool is a candidate set GUARANTEED to contain the coupled
+file, so truncating it (and possibly dropping that file) defeats the purpose.
+``truncated`` is surfaced so the agent knows when the cap bit."""
+
+
+async def _resolve_file(
+    g, file: Any, project: Optional[str]
+) -> tuple[Optional[int], Optional[str]]:
+    """Resolve a File handle to ``(file_node_id, abs_path)``.
+
+    ``file`` is either the integer File-node id that ``search_code`` returns,
+    or a repo-relative path. Path resolution compares ``_relativize`` of each
+    stored ``File.path`` rather than reconstructing an absolute path (worktree
+    roots vary), so a relative path matches regardless of the indexing root.
+    """
+    try:
+        fid = _coerce_node_id(file)
+    except ValueError:
+        fid = None
+    if fid is not None:
+        res = await g._query(
+            "MATCH (f:File) WHERE ID(f) = $id RETURN f.path", {"id": fid}
+        )
+        if res.result_set and res.result_set[0][0]:
+            return fid, res.result_set[0][0]
+        return None, None
+    target = str(file).strip().lstrip("/")
+    res = await g._query("MATCH (f:File) RETURN ID(f), f.path")
+    for nid, ap in res.result_set:
+        if ap and (_relativize(ap, project) == target or ap == file):
+            return nid, ap
+    return None, None
+
+
+@app.tool(
+    name="get_file_neighbors",
+    description=(
+        "Files structurally coupled to a FILE — the import/call/inheritance "
+        "dependencies that a textual search misses and that must often change "
+        "together. Run after `search_code`, passing a hit's `file_id` (or a "
+        "repo-relative path). Expands EVERY symbol in the file (not just the "
+        "representative one) and unions 1-hop IMPORTS/CALLS/EXTENDS/OVERRIDES "
+        "edges in both directions, deduped to files and ordered by coupling "
+        "strength (edge count). Returns {file, total_neighbors, truncated, "
+        "neighbors:[{file, file_id, edge_count, relations, snippet}]}. Each "
+        "neighbor carries a `file_id` you can recurse on and a code `snippet`. "
+        "Use this to reach co-change files after localizing the primary hit."
+    ),
+)
+async def get_file_neighbors(
+    file: Any,
+    project: str,
+    branch: Optional[str] = None,
+    limit: int = FILE_NEIGHBOR_MAX,
+) -> dict[str, Any]:
+    g = _project_arg(project, branch)
+    try:
+        fid, abs_path = await _resolve_file(g, file, project)
+        if abs_path is None:
+            return {
+                "file": _relativize(str(file), project),
+                "total_neighbors": 0,
+                "truncated": False,
+                "neighbors": [],
+            }
+
+        sres = await g._query(
+            "MATCH (n) WHERE (n:Function OR n:Class) AND n.path = $p RETURN ID(n)",
+            {"p": abs_path},
+        )
+        ids = [row[0] for row in sres.result_set]
+        if fid is not None:
+            ids.append(fid)
+        if not ids:
+            return {
+                "file": _relativize(abs_path, project),
+                "total_neighbors": 0,
+                "truncated": False,
+                "neighbors": [],
+            }
+
+        relq = "|".join(FILE_NEIGHBOR_RELS)
+        # Aggregate first (group by neighbor file), sort second, limit last — so
+        # high-degree symbols can't crowd the coupled file out before ranking.
+        agg: dict[str, dict[str, Any]] = {}
+        for direction in ("OUT", "IN"):
+            if direction == "OUT":
+                q = (
+                    f"MATCH (n)-[e:{relq}]->(d) WHERE ID(n) IN $ids "
+                    "AND d.path IS NOT NULL AND d.path <> $self "
+                    "RETURN d.path AS p, type(e) AS rel"
+                )
+            else:
+                q = (
+                    f"MATCH (s)-[e:{relq}]->(n) WHERE ID(n) IN $ids "
+                    "AND s.path IS NOT NULL AND s.path <> $self "
+                    "RETURN s.path AS p, type(e) AS rel"
+                )
+            res = await g._query(q, {"ids": ids, "self": abs_path})
+            for ap, rel in res.result_set:
+                rp = _relativize(ap, project)
+                slot = agg.get(rp)
+                if slot is None:
+                    slot = {"abs": ap, "count": 0, "rels": Counter()}
+                    agg[rp] = slot
+                slot["count"] += 1
+                slot["rels"][f"{rel}:{direction}"] += 1
+
+        total = len(agg)
+        eff_limit = min(int(limit or FILE_NEIGHBOR_MAX), FILE_NEIGHBOR_MAX)
+        ordered = sorted(agg.items(), key=lambda kv: (-kv[1]["count"], kv[0]))
+        kept = ordered[:eff_limit]
+        kept_abs = [slot["abs"] for _, slot in kept]
+
+        # Batch the File-id and representative-symbol (lowest src_start) lookups
+        # for only the kept neighbors.
+        fid_of: dict[str, int] = {}
+        if kept_abs:
+            fres = await g._query(
+                "MATCH (f:File) WHERE f.path IN $paths RETURN f.path, ID(f)",
+                {"paths": kept_abs},
+            )
+            fid_of = {row[0]: row[1] for row in fres.result_set}
+        rep_of: dict[str, tuple] = {}
+        if kept_abs:
+            rres = await g._query(
+                "MATCH (n) WHERE (n:Function OR n:Class) AND n.path IN $paths "
+                "RETURN n.path, n.src_start, n.src_end ORDER BY n.src_start",
+                {"paths": kept_abs},
+            )
+            for ap, s0, s1 in rres.result_set:
+                rep_of.setdefault(ap, (s0, s1))
+
+        neighbors: list[dict[str, Any]] = []
+        for rp, slot in kept:
+            ap = slot["abs"]
+            entry: dict[str, Any] = {
+                "file": rp,
+                "file_id": fid_of.get(ap),
+                "edge_count": slot["count"],
+                "relations": dict(slot["rels"]),
+            }
+            rep = rep_of.get(ap)
+            if rep:
+                snip = _read_snippet(ap, rep[0], rep[1], NEIGHBOR_SNIPPET_LINES)
+                if snip:
+                    entry["snippet"] = snip
+            neighbors.append(entry)
+
+        return {
+            "file": _relativize(abs_path, project),
+            "file_id": fid,
+            "total_neighbors": total,
+            "truncated": total > eff_limit,
+            "neighbors": neighbors,
+        }
+    finally:
+        await g.close()
 
 
 # Hard cap on traversal depth — passed values above this are silently
@@ -515,13 +1160,15 @@ def _clamp_depth(depth: Any) -> int:
 @app.tool(
     name="impact_analysis",
     description=(
-        "Transitive call-graph impact for refactoring: "
-        "`direction='IN'` returns all upstream callers (what breaks if you "
-        "change this symbol); `direction='OUT'` returns all downstream "
-        "callees (what this symbol indirectly depends on). Traverses only "
-        f"CALLS edges. Depth is clamped to {IMPACT_MAX_DEPTH}; cycles are "
-        "deduplicated via Cypher DISTINCT (each node appears at most once). "
-        "`limit` bounds the number of impacted symbols returned."
+        "Find the files/functions connected to a symbol through the call graph "
+        "— the files that must change TOGETHER when fixing or modifying it. "
+        "`direction='IN'` = upstream callers (who depends on this); "
+        "`direction='OUT'` = downstream callees (what this relies on). "
+        f"Traverses only CALLS edges (static; dynamic dispatch not captured); "
+        f"depth clamped to {IMPACT_MAX_DEPTH}; cycles deduplicated via Cypher "
+        "DISTINCT. `limit` bounds the number of impacted symbols returned. "
+        "For localization, run IN on a confirmed-buggy symbol to "
+        "surface co-change files."
     ),
 )
 async def impact_analysis(
@@ -565,7 +1212,7 @@ async def impact_analysis(
 
     out: list[dict[str, Any]] = []
     for row in res.result_set:
-        entry = _node_summary(row[0])
+        entry = _node_summary(row[0], rel_to=project, with_label=False)
         entry["direction"] = direction
         out.append(entry)
     return out

--- a/api/mcp/tools/structural.py
+++ b/api/mcp/tools/structural.py
@@ -752,11 +752,60 @@ _SNIPPET_LINE_CHARS = 200
 """Per-line char cap so a single minified line cannot blow up the payload."""
 
 
+def _is_within(path: str, root: str) -> bool:
+    """True when ``path`` is ``root`` or lives inside it (both absolute)."""
+    try:
+        return os.path.commonpath([path, root]) == root
+    except ValueError:
+        # Different drives / mixed absolute-relative -> not contained.
+        return False
+
+
+def _snippet_path_allowed(abs_path: str, project: Optional[str]) -> bool:
+    """Symlink-safe guard for snippet file reads.
+
+    Snippet paths come from indexed ``File.path`` values, i.e. ultimately from
+    repo content. A malicious repo could store (or symlink) a path resolving
+    outside the indexed worktree, turning a snippet read into an arbitrary
+    host-file read. We resolve the real path (following symlinks) and require it
+    to live inside an allowed root: ``ALLOWED_ANALYSIS_DIR`` when set, and/or the
+    indexed repo root derived from the first ``/<project>/`` marker in the
+    stored path. When neither root is derivable (no allow-list and no project
+    marker in the path) we preserve the legacy read rather than block a
+    legitimate snippet.
+    """
+    try:
+        real = os.path.realpath(abs_path)
+    except OSError:
+        return False
+
+    roots: list[str] = []
+    allowed_env = os.getenv("ALLOWED_ANALYSIS_DIR")
+    if allowed_env:
+        try:
+            roots.append(os.path.realpath(os.path.expanduser(allowed_env)))
+        except OSError:
+            pass
+    if project:
+        marker = f"/{project}/"
+        idx = abs_path.find(marker)
+        if idx != -1:
+            try:
+                roots.append(os.path.realpath(abs_path[: idx + len(marker)]))
+            except OSError:
+                pass
+
+    if not roots:
+        return True
+    return any(_is_within(real, root) for root in roots)
+
+
 def _read_snippet(
     abs_path: Optional[str],
     src_start: Any,
     src_end: Any,
     max_lines: int,
+    project: Optional[str] = None,
 ) -> Optional[str]:
     """Read up to ``max_lines`` leading source lines for an entity from disk.
 
@@ -766,8 +815,14 @@ def _read_snippet(
     info is missing or unreadable. Each line is capped at
     ``_SNIPPET_LINE_CHARS``. Carrying a snippet in the result lets a single
     tool call replace a follow-up ``view`` of a large file.
+
+    ``project`` (the indexed repo identifier) enables a symlink-safe allow-list
+    check via :func:`_snippet_path_allowed` so a snippet read can't escape the
+    indexed worktree.
     """
     if not abs_path or max_lines <= 0:
+        return None
+    if not _snippet_path_allowed(abs_path, project):
         return None
     try:
         start = int(src_start)
@@ -852,6 +907,7 @@ def _node_summary(
             props.get("src_start"),
             props.get("src_end"),
             snippet_lines,
+            project=rel_to,
         )
         if snip:
             summary["snippet"] = snip
@@ -1206,6 +1262,7 @@ async def search_code(
             r["src_start"] if r["src_start"] is not None else 1,
             r["src_end"] if r["src_end"] is not None else r["src_start"],
             SEARCH_SNIPPET_LINES,
+            project=project,
         )
         if snip:
             rec["snippet"] = snip
@@ -1366,7 +1423,9 @@ async def get_file_neighbors(
             }
             rep = rep_of.get(ap)
             if rep:
-                snip = _read_snippet(ap, rep[0], rep[1], NEIGHBOR_SNIPPET_LINES)
+                snip = _read_snippet(
+                    ap, rep[0], rep[1], NEIGHBOR_SNIPPET_LINES, project=project
+                )
                 if snip:
                     entry["snippet"] = snip
             neighbors.append(entry)

--- a/api/mcp/tools/structural.py
+++ b/api/mcp/tools/structural.py
@@ -100,6 +100,22 @@ def _minmax(d: dict[str, float]) -> dict[str, float]:
     return {k: (v - lo) / (hi - lo) for k, v in d.items()}
 
 
+def _rep_key(d: dict[str, Any]) -> tuple:
+    """Stable ordering key for a file's representative-symbol candidate.
+
+    Lower is better: exact query-id match first, then lowest ``src_start``,
+    then ``name`` then ``src_end`` as deterministic tie-breakers so the chosen
+    representative never depends on FalkorDB row order (even when ``src_start``
+    ties or is missing).
+    """
+    return (
+        0 if d.get("exact") else 1,
+        d["src_start"] if d.get("src_start") is not None else math.inf,
+        d.get("name") or "",
+        d["src_end"] if d.get("src_end") is not None else math.inf,
+    )
+
+
 def _bm25(query_tokens: set[str], files: list[str],
           tokmap: dict[str, list[str]]) -> dict[str, float]:
     docs = [tokmap.get(f, []) for f in files]
@@ -141,7 +157,11 @@ async def _hybrid_rank(g, query: str, project: Optional[str]) -> list[dict[str, 
     symbol per file, used for the snippet). Pure read; no graph mutation.
     """
     files, comps, rep, abs_of, file_id_of = await _hybrid_components(g, query, project)
-    return _hybrid_score(files, comps, rep, abs_of, file_id_of)
+    scored = _hybrid_score(files, comps, rep, abs_of, file_id_of)
+    # Relevance floor: a query with no lexical overlap (e.g. a nonsense token)
+    # would otherwise be ranked purely by query-independent centrality and
+    # return noise. Drop files with no lexical signal so such queries yield [].
+    return [r for r in scored if r.get("lex", 0.0) > 0]
 
 
 async def _hybrid_components(g, query: str, project: Optional[str]):
@@ -194,14 +214,19 @@ async def _hybrid_components(g, query: str, project: Optional[str]):
             continue
         if name:
             bodytok[rp].extend(_subtokens(name))
-            if name.lower() in qids:
+            is_exact = name.lower() in qids
+            if is_exact:
                 name_exact[rp] += 1.0
-                rep.setdefault(rp, {"name": name, "src_start": start, "src_end": end})
-        if rp not in rep and name:
+            # Representative symbol for the file's snippet: prefer one whose name
+            # exactly matches a query identifier, otherwise the lowest-``src_start``
+            # symbol. Fully deterministic regardless of result-set order via a
+            # stable sort key (exact first, then src_start, then name, then
+            # src_end) so ties / missing ``src_start`` never depend on row order.
+            cand = {"name": name, "src_start": start, "src_end": end,
+                    "exact": is_exact}
             cur = rep.get(rp)
-            if cur is None or (start is not None and (
-                cur.get("src_start") is None or start < cur["src_start"])):
-                rep[rp] = {"name": name, "src_start": start, "src_end": end}
+            if cur is None or _rep_key(cand) < _rep_key(cur):
+                rep[rp] = cand
         if doc and body_used[rp] < _HYBRID_BODY_TOKEN_CAP:
             toks = _tokenize(doc)[: _HYBRID_BODY_TOKEN_CAP - body_used[rp]]
             bodytok[rp].extend(toks)
@@ -221,9 +246,10 @@ async def _hybrid_components(g, query: str, project: Optional[str]):
         return [], {}, {}, {}, {}
 
     path_overlap = {f: float(len(qtok & set(pathtok.get(f, [])))) for f in files}
+    raw_bm25 = _bm25(qtok, files, bodytok)
     n_name = _minmax(name_exact if name_exact else {f: 0.0 for f in files})
     n_path = _minmax(path_overlap)
-    n_bm25 = _minmax(_bm25(qtok, files, bodytok))
+    n_bm25 = _minmax(raw_bm25)
     n_cent = _minmax({f: centrality.get(f, 0.0) for f in files})
 
     comps: dict[str, dict[str, float]] = {}
@@ -234,6 +260,13 @@ async def _hybrid_components(g, query: str, project: Optional[str]):
             "bm25": n_bm25.get(f, 0.0),
             "cent": n_cent.get(f, 0.0),
             "pen": _HYBRID_W_PEN if _PENALTY_RE.search(f) else 0.0,
+            # Raw (un-normalized) query-dependent signal. A file with zero
+            # lexical overlap (name/path/body) is not relevant to the query —
+            # only query-independent centrality could rank it — so search_code
+            # drops it rather than returning noise for an unmatched query.
+            "lex": (name_exact.get(f, 0.0)
+                    + path_overlap.get(f, 0.0)
+                    + raw_bm25.get(f, 0.0)),
         }
 
     return files, comps, rep, abs_of, file_id_of
@@ -271,6 +304,7 @@ def _hybrid_score(
             "name": r.get("name"),
             "src_start": r.get("src_start"),
             "src_end": r.get("src_end"),
+            "lex": c.get("lex", 0.0),
         })
     scored.sort(key=lambda d: -d["score"])
     return scored
@@ -575,9 +609,10 @@ def _node_summary(
     ``encode_node`` returns ``{id, labels, properties: {...}}`` because Node
     properties live on a nested attribute. Agents want a flat record. We keep
     the single meaningful ``label`` (File, Class, Function — not the fulltext
-    marker ``Searchable``) only for ``search_code``, where File-vs-Function
-    disambiguation matters; neighbor/path results omit it via ``with_label``
-    since the relation already implies the type.
+    marker ``Searchable``) for ``search_code`` (File-vs-Function disambiguation)
+    and for ``find_path`` (a path is bare nodes with no per-hop relation, so the
+    label is the only type signal). Single-hop neighbor results omit it via
+    ``with_label`` since the relation already implies the node type.
 
     When ``rel_to`` is given (the project/worktree identifier), ``file`` is
     relativized to drop the absolute worktree prefix.
@@ -893,7 +928,7 @@ async def find_path(
     paths: list[dict[str, Any]] = []
     for entry in raw:
         node_seq = [
-            _node_summary(x, rel_to=project, with_label=False)
+            _node_summary(x, rel_to=project, with_label=True)
             for x in entry
             # Discriminate on ``labels``: ``encode_node`` emits a top-level
             # ``labels`` key, while ``encode_edge`` does not (edges carry
@@ -1036,6 +1071,7 @@ async def get_file_neighbors(
         if abs_path is None:
             return {
                 "file": _relativize(str(file), project),
+                "file_id": None,
                 "total_neighbors": 0,
                 "truncated": False,
                 "neighbors": [],
@@ -1051,6 +1087,7 @@ async def get_file_neighbors(
         if not ids:
             return {
                 "file": _relativize(abs_path, project),
+                "file_id": fid,
                 "total_neighbors": 0,
                 "truncated": False,
                 "neighbors": [],

--- a/tests/mcp/test_impact_analysis.py
+++ b/tests/mcp/test_impact_analysis.py
@@ -69,17 +69,25 @@ async def test_impact_analysis_registered_via_app():
 
 
 async def _find_id(indexed_fixture, name: str) -> int:
-    from api.mcp.tools.structural import search_code
+    """Resolve a symbol name to its int node id directly from the graph.
 
-    rows = await search_code(
-        prefix=name,
-        project=indexed_fixture.project,
-        branch=indexed_fixture.branch,
-    )
-    for r in rows:
-        if r["name"] == name:
-            return r["id"]
-    raise AssertionError(f"symbol {name!r} not found")
+    ``search_code`` is file-oriented and no longer returns per-symbol ids.
+    """
+    from api.mcp.tools.structural import _project_arg
+
+    g = _project_arg(indexed_fixture.project, indexed_fixture.branch)
+    try:
+        res = await g._query(
+            "MATCH (n) WHERE (n:Function OR n:Class) AND n.name = $name "
+            "RETURN ID(n)",
+            {"name": name},
+        )
+    finally:
+        await g.close()
+    rows = res.result_set
+    assert rows, f"symbol {name!r} not found in graph"
+    assert len(rows) == 1, f"ambiguous symbol {name!r}: {len(rows)} matches"
+    return rows[0][0]
 
 
 async def test_impact_upstream_of_db(indexed_fixture, expected_contract):

--- a/tests/mcp/test_query_tools.py
+++ b/tests/mcp/test_query_tools.py
@@ -28,21 +28,23 @@ def anyio_backend() -> str:
 async def test_search_code_finds_entrypoint(indexed_fixture, expected_contract):
     from api.mcp.tools.structural import search_code
 
+    # search_code is file-oriented: a free-text query naming a symbol must
+    # surface the file that defines it.
+    symbol = expected_contract["search_prefixes"]["ent"]["must_include"][0]
     results = await search_code(
-        prefix="ent",
+        query=symbol,
         project=indexed_fixture.project,
         branch=indexed_fixture.branch,
     )
-    names = {r["name"] for r in results}
-    for required in expected_contract["search_prefixes"]["ent"]["must_include"]:
-        assert required in names, f"expected {required} in {names}"
+    files = [r["file"] for r in results if r.get("file")]
+    assert any(f.endswith(f"{symbol}.py") for f in files), files
 
 
 async def test_search_code_honors_limit(indexed_fixture):
     from api.mcp.tools.structural import search_code
 
     results = await search_code(
-        prefix="r",  # broad prefix
+        query="entrypoint service repo db",  # broad: matches several files
         project=indexed_fixture.project,
         branch=indexed_fixture.branch,
         limit=1,
@@ -54,7 +56,7 @@ async def test_search_code_empty_for_nonsense(indexed_fixture):
     from api.mcp.tools.structural import search_code
 
     results = await search_code(
-        prefix="zzz_no_such_symbol_zzz",
+        query="zzz_no_such_symbol_zzz",
         project=indexed_fixture.project,
         branch=indexed_fixture.branch,
     )
@@ -65,7 +67,7 @@ async def test_search_code_result_serialisable(indexed_fixture):
     from api.mcp.tools.structural import search_code
 
     results = await search_code(
-        prefix="serv",
+        query="service",
         project=indexed_fixture.project,
         branch=indexed_fixture.branch,
     )
@@ -101,7 +103,7 @@ async def test_search_code_returns_relative_paths(indexed_fixture):
     from api.mcp.tools.structural import search_code
 
     results = await search_code(
-        prefix="ent",
+        query="entrypoint",
         project=indexed_fixture.project,
         branch=indexed_fixture.branch,
     )
@@ -112,20 +114,20 @@ async def test_search_code_returns_relative_paths(indexed_fixture):
 
 
 async def test_search_code_ranks_exact_match_within_limit(indexed_fixture, expected_contract):
-    """An exact name==prefix match must survive the ``[:limit]`` cut and rank
-    ahead of the looser prefix matches."""
+    """A query naming a symbol must surface that symbol's file as the top hit,
+    with the matching symbol as the file's representative."""
     from api.mcp.tools.structural import search_code
 
-    # pick a known symbol from the contract and query its exact name
-    exact = next(iter(expected_contract["search_prefixes"]["ent"]["must_include"]))
+    symbol = next(iter(expected_contract["search_prefixes"]["ent"]["must_include"]))
     results = await search_code(
-        prefix=exact,
+        query=symbol,
         project=indexed_fixture.project,
         branch=indexed_fixture.branch,
         limit=1,
     )
-    assert results, f"no results for exact prefix {exact!r}"
-    assert results[0]["name"] == exact
+    assert results, f"no results for query {symbol!r}"
+    assert results[0]["file"].endswith(f"{symbol}.py")
+    assert results[0]["name"] == symbol
 
 
 # ---------------------------------------------------------------------------
@@ -134,18 +136,28 @@ async def test_search_code_ranks_exact_match_within_limit(indexed_fixture, expec
 
 
 async def _find_id(indexed_fixture, name: str) -> int:
-    """Helper: resolve a symbol name to its int node id via search_code."""
-    from api.mcp.tools.structural import search_code
+    """Resolve a symbol name to its int node id directly from the graph.
 
-    rows = await search_code(
-        prefix=name,
-        project=indexed_fixture.project,
-        branch=indexed_fixture.branch,
-    )
-    for r in rows:
-        if r["name"] == name:
-            return r["id"]
-    raise AssertionError(f"symbol {name!r} not found via search_code")
+    ``search_code`` is file-oriented and no longer returns per-symbol ids, so
+    the neighbor/path/impact tests resolve the id straight from FalkorDB. The
+    names used here (entrypoint/service/db) are unique Functions in the fixture,
+    so a uniqueness assertion guards against silently picking the wrong node.
+    """
+    from api.mcp.tools.structural import _project_arg
+
+    g = _project_arg(indexed_fixture.project, indexed_fixture.branch)
+    try:
+        res = await g._query(
+            "MATCH (n) WHERE (n:Function OR n:Class) AND n.name = $name "
+            "RETURN ID(n)",
+            {"name": name},
+        )
+    finally:
+        await g.close()
+    rows = res.result_set
+    assert rows, f"symbol {name!r} not found in graph"
+    assert len(rows) == 1, f"ambiguous symbol {name!r}: {len(rows)} matches"
+    return rows[0][0]
 
 
 async def test_get_callees_of_entrypoint(indexed_fixture, expected_contract):

--- a/tests/mcp/test_query_tools.py
+++ b/tests/mcp/test_query_tools.py
@@ -72,6 +72,62 @@ async def test_search_code_result_serialisable(indexed_fixture):
     json.dumps(results)  # must not raise
 
 
+def test_relativize_strips_worktree_prefix():
+    from api.mcp.tools.structural import _relativize
+
+    proj = "django__django-18854__loc"
+    abs_path = f"/Users/x/.worktrees/bench/worktrees/code_graph/{proj}/django/db/models/fields/__init__.py"
+    assert _relativize(abs_path, proj) == "django/db/models/fields/__init__.py"
+
+
+def test_relativize_keeps_nested_repeat_of_project_name():
+    """A nested dir repeating the project name must survive (first-match strip)."""
+    from api.mcp.tools.structural import _relativize
+
+    proj = "myproj"
+    abs_path = f"/root/{proj}/src/vendor/{proj}/file.py"
+    assert _relativize(abs_path, proj) == f"src/vendor/{proj}/file.py"
+
+
+def test_relativize_noops_without_marker_or_rel_to():
+    from api.mcp.tools.structural import _relativize
+
+    assert _relativize("/abs/path/no/marker.py", "absent") == "/abs/path/no/marker.py"
+    assert _relativize("/abs/path.py", None) == "/abs/path.py"
+    assert _relativize(None, "proj") is None
+
+
+async def test_search_code_returns_relative_paths(indexed_fixture):
+    from api.mcp.tools.structural import search_code
+
+    results = await search_code(
+        prefix="ent",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    for r in results:
+        if r.get("file"):
+            assert not r["file"].startswith("/"), f"path not relativized: {r['file']}"
+            assert f"/{indexed_fixture.project}/" not in r["file"]
+
+
+async def test_search_code_ranks_exact_match_within_limit(indexed_fixture, expected_contract):
+    """An exact name==prefix match must survive the ``[:limit]`` cut and rank
+    ahead of the looser prefix matches."""
+    from api.mcp.tools.structural import search_code
+
+    # pick a known symbol from the contract and query its exact name
+    exact = next(iter(expected_contract["search_prefixes"]["ent"]["must_include"]))
+    results = await search_code(
+        prefix=exact,
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+        limit=1,
+    )
+    assert results, f"no results for exact prefix {exact!r}"
+    assert results[0]["name"] == exact
+
+
 # ---------------------------------------------------------------------------
 # get_callers / get_callees / get_dependencies (T5)
 # ---------------------------------------------------------------------------
@@ -266,8 +322,138 @@ async def test_all_query_tools_registered():
     tools = {t.name for t in await app.list_tools()}
     assert {
         "search_code",
-        "get_callers",
-        "get_callees",
-        "get_dependencies",
+        "get_neighbors",
         "find_path",
     }.issubset(tools)
+    # The per-edge tools were consolidated into get_neighbors and must no
+    # longer be advertised on the MCP surface.
+    assert tools.isdisjoint(
+        {"get_callers", "get_callees", "get_dependencies", "get_importers", "get_overrides"}
+    )
+
+
+async def test_get_neighbors_matches_legacy_callers_callees(indexed_fixture):
+    from api.mcp.tools.structural import get_callees, get_callers, get_neighbors
+
+    project = indexed_fixture.project
+    branch = indexed_fixture.branch
+    entry_id = await _find_id(indexed_fixture, "entrypoint")
+
+    legacy_callees = await get_callees(symbol_id=entry_id, project=project, branch=branch)
+    unified_callees = await get_neighbors(
+        symbol_id=entry_id, project=project, branch=branch, relation="CALLS", direction="OUT"
+    )
+    assert {n["id"] for n in unified_callees} == {n["id"] for n in legacy_callees}
+
+    service_id = await _find_id(indexed_fixture, "service")
+    legacy_callers = await get_callers(symbol_id=service_id, project=project, branch=branch)
+    unified_callers = await get_neighbors(
+        symbol_id=service_id, project=project, branch=branch, relation="CALLS", direction="IN"
+    )
+    assert {n["id"] for n in unified_callers} == {n["id"] for n in legacy_callers}
+
+
+async def test_get_neighbors_matches_legacy_dependencies(indexed_fixture):
+    from api.mcp.tools.structural import get_dependencies, get_neighbors
+
+    project = indexed_fixture.project
+    branch = indexed_fixture.branch
+    entry_id = await _find_id(indexed_fixture, "entrypoint")
+
+    legacy = await get_dependencies(symbol_id=entry_id, project=project, branch=branch)
+    unified = await get_neighbors(
+        symbol_id=entry_id,
+        project=project,
+        branch=branch,
+        relation=["IMPORTS", "CALLS", "DEFINES"],
+        direction="OUT",
+    )
+    assert {n["id"] for n in unified} == {n["id"] for n in legacy}
+
+
+# ---------------------------------------------------------------------------
+# get_file_neighbors (T8b) — file-level structural coupling
+# ---------------------------------------------------------------------------
+
+
+async def test_get_file_neighbors_reaches_cross_file_dependency(indexed_fixture):
+    """File-level expansion must reach a cross-file dependency.
+
+    ``entrypoint()`` calls ``service()`` in another file, so ``service.py``
+    must surface as a neighbor — and crucially via expanding ALL symbols in
+    the file, not only the lowest-``src_start`` representative one.
+    """
+    from api.mcp.tools.structural import get_file_neighbors
+
+    res = await get_file_neighbors(
+        "python/entrypoint.py",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    assert isinstance(res, dict)
+    assert res["file"] == "python/entrypoint.py"
+    assert res["truncated"] is False
+    assert res["total_neighbors"] == len(res["neighbors"])
+
+    names = [n["file"] for n in res["neighbors"]]
+    assert any(n.endswith("service.py") for n in names), names
+    assert "python/entrypoint.py" not in names  # self excluded
+
+    for n in res["neighbors"]:
+        assert isinstance(n["file_id"], int)  # recursable handle
+        assert n["edge_count"] >= 1
+        assert n["relations"]  # relation:direction breakdown present
+
+
+async def test_get_file_neighbors_id_and_path_agree(indexed_fixture):
+    """Resolving by File-node id and by repo-relative path yields the same set."""
+    from api.mcp.tools.structural import get_file_neighbors
+
+    by_path = await get_file_neighbors(
+        "python/service.py",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    assert by_path["file_id"] is not None
+    by_id = await get_file_neighbors(
+        by_path["file_id"],
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    assert [n["file"] for n in by_id["neighbors"]] == [
+        n["file"] for n in by_path["neighbors"]
+    ]
+
+
+async def test_get_file_neighbors_unknown_file_is_empty(indexed_fixture):
+    from api.mcp.tools.structural import get_file_neighbors
+
+    res = await get_file_neighbors(
+        "python/does_not_exist.py",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    assert res["total_neighbors"] == 0
+    assert res["neighbors"] == []
+    assert res["truncated"] is False
+
+
+async def test_search_code_returns_file_id(indexed_fixture):
+    """Every search_code hit must carry a File-node ``file_id`` to hop from."""
+    from api.mcp.tools.structural import search_code
+
+    rows = await search_code(
+        query="service repo db",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    assert rows, "expected at least one hit"
+    for r in rows:
+        assert isinstance(r["file_id"], int)
+
+
+async def test_get_file_neighbors_registered():
+    from api.mcp.server import app
+
+    tools = await app.list_tools()
+    assert "get_file_neighbors" in {t.name for t in tools}

--- a/tests/mcp/test_search_cache.py
+++ b/tests/mcp/test_search_cache.py
@@ -90,6 +90,8 @@ def synth_graph():
         try:
             g.delete()
         except Exception:
+            # Best-effort teardown: never fail a test because cleanup couldn't
+            # reach FalkorDB or the throwaway graph was already gone.
             pass
 
 
@@ -112,7 +114,7 @@ async def test_warm_call_reuses_corpus(synth_graph, monkeypatch):
     import api.mcp.tools.structural as S
     from api.graph import AsyncGraphQuery
 
-    name, project, branch = synth_graph
+    name, project, _branch = synth_graph
     calls = _spy_build(monkeypatch)
 
     g = AsyncGraphQuery(name)
@@ -131,7 +133,7 @@ async def test_different_queries_share_one_corpus(synth_graph, monkeypatch):
     import api.mcp.tools.structural as S
     from api.graph import AsyncGraphQuery
 
-    name, project, branch = synth_graph
+    name, project, _branch = synth_graph
     calls = _spy_build(monkeypatch)
 
     g = AsyncGraphQuery(name)
@@ -149,7 +151,7 @@ async def test_signature_change_triggers_rebuild(synth_graph, monkeypatch):
     import api.mcp.tools.structural as S
     from api.graph import AsyncGraphQuery
 
-    name, project, branch = synth_graph
+    name, project, _branch = synth_graph
     calls = _spy_build(monkeypatch)
 
     g = AsyncGraphQuery(name)
@@ -172,7 +174,7 @@ async def test_reset_corpus_cache_forces_rebuild(synth_graph, monkeypatch):
     import api.mcp.tools.structural as S
     from api.graph import AsyncGraphQuery
 
-    name, project, branch = synth_graph
+    name, project, _branch = synth_graph
     calls = _spy_build(monkeypatch)
 
     g = AsyncGraphQuery(name)
@@ -192,7 +194,7 @@ async def test_reset_all_clears_every_graph(synth_graph, monkeypatch):
     import api.mcp.tools.structural as S
     from api.graph import AsyncGraphQuery
 
-    name, project, branch = synth_graph
+    name, project, _branch = synth_graph
     calls = _spy_build(monkeypatch)
 
     g = AsyncGraphQuery(name)
@@ -217,7 +219,7 @@ async def test_concurrent_first_calls_build_once(synth_graph, monkeypatch):
     import api.mcp.tools.structural as S
     from api.graph import AsyncGraphQuery
 
-    name, project, branch = synth_graph
+    name, project, _branch = synth_graph
     calls = _spy_build(monkeypatch)
 
     async def one():
@@ -238,7 +240,7 @@ async def test_mutation_during_build_is_not_cached(synth_graph, monkeypatch):
     import api.mcp.tools.structural as S
     from api.graph import AsyncGraphQuery
 
-    name, project, branch = synth_graph
+    name, project, _branch = synth_graph
 
     g_probe = AsyncGraphQuery(name)
     orig = S._build_corpus

--- a/tests/mcp/test_search_cache.py
+++ b/tests/mcp/test_search_cache.py
@@ -1,0 +1,262 @@
+"""Corpus-cache tests for the search_code hot path (PR #701).
+
+``search_code``'s ranker caches the query-independent corpus (three full-graph
+reads + tokenization) per ``(graph, project)`` and applies only a cheap
+per-query overlay on each call. These tests pin the cache contract:
+
+* a warm call reuses the corpus (no rebuild) and returns identical results;
+* the ``(node_count, edge_count, commit)`` signature probe rebuilds when the
+  graph mutates;
+* ``reset_corpus_cache`` (the ``index_repo`` hook) forces a rebuild;
+* concurrent first-time calls rebuild exactly once (per-key lock).
+
+They build tiny synthetic graphs with raw Cypher rather than the shared
+session ``indexed_fixture`` so a mutation test can never corrupt other tests.
+Each needs a reachable FalkorDB.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _falkordb_reachable() -> bool:
+    try:
+        from falkordb import FalkorDB
+
+        host = os.getenv("FALKORDB_HOST", "localhost")
+        port = int(os.getenv("FALKORDB_PORT", 6379))
+        return bool(FalkorDB(host=host, port=port, socket_timeout=1).connection.ping())
+    except Exception:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    """Reset module-global cache state around every test."""
+    import api.mcp.tools.structural as S
+
+    S.reset_corpus_cache()
+    S._CORPUS_LOCKS.clear()
+    yield
+    S.reset_corpus_cache()
+    S._CORPUS_LOCKS.clear()
+
+
+@pytest.fixture
+def synth_graph():
+    """A tiny two-file graph seeded via raw Cypher, dropped on teardown.
+
+    Paths embed ``/<project>/`` so ``_relativize`` yields stable repo-relative
+    keys (project == ``proj``). Yields ``(graph_name, project, branch)``.
+    """
+    if not _falkordb_reachable():
+        pytest.skip("FalkorDB not reachable on $FALKORDB_HOST:$FALKORDB_PORT")
+
+    from falkordb import FalkorDB
+
+    project = "proj"
+    branch = f"cachetest-{uuid.uuid4().hex[:8]}"
+    name = f"code:{project}:{branch}"
+
+    host = os.getenv("FALKORDB_HOST", "localhost")
+    port = int(os.getenv("FALKORDB_PORT", 6379))
+    db = FalkorDB(host=host, port=port)
+    g = db.select_graph(name)
+    g.query(
+        "CREATE "
+        "(a:File {path:'/root/proj/alpha.py'}), "
+        "(b:File {path:'/root/proj/beta.py'}), "
+        "(fa:Function {name:'parse_tokens', path:'/root/proj/alpha.py', "
+        "src_start:1, src_end:9, doc:'parse the tokens of a query'}), "
+        "(fb:Function {name:'resolve_symbol', path:'/root/proj/beta.py', "
+        "src_start:1, src_end:9, doc:'resolve a symbol to its node'}), "
+        "(fb)-[:CALLS]->(fa)"
+    )
+    try:
+        yield name, project, branch
+    finally:
+        try:
+            g.delete()
+        except Exception:
+            pass
+
+
+def _spy_build(monkeypatch):
+    """Wrap _build_corpus with a call counter; returns the counter dict."""
+    import api.mcp.tools.structural as S
+
+    calls = {"n": 0}
+    orig = S._build_corpus
+
+    async def counting(g, project):
+        calls["n"] += 1
+        return await orig(g, project)
+
+    monkeypatch.setattr(S, "_build_corpus", counting)
+    return calls
+
+
+async def test_warm_call_reuses_corpus(synth_graph, monkeypatch):
+    import api.mcp.tools.structural as S
+    from api.graph import AsyncGraphQuery
+
+    name, project, branch = synth_graph
+    calls = _spy_build(monkeypatch)
+
+    g = AsyncGraphQuery(name)
+    try:
+        first = await S._hybrid_rank(g, "parse tokens", project)
+        second = await S._hybrid_rank(g, "parse tokens", project)
+    finally:
+        await g.close()
+
+    assert calls["n"] == 1, "second call should hit the cache, not rebuild"
+    assert first == second
+    assert any("alpha.py" in r["file"] for r in first), first
+
+
+async def test_different_queries_share_one_corpus(synth_graph, monkeypatch):
+    import api.mcp.tools.structural as S
+    from api.graph import AsyncGraphQuery
+
+    name, project, branch = synth_graph
+    calls = _spy_build(monkeypatch)
+
+    g = AsyncGraphQuery(name)
+    try:
+        await S._hybrid_rank(g, "parse tokens", project)
+        await S._hybrid_rank(g, "resolve symbol", project)
+        await S._hybrid_rank(g, "nonsense_zzz", project)
+    finally:
+        await g.close()
+
+    assert calls["n"] == 1, "corpus is query-independent: build once for many queries"
+
+
+async def test_signature_change_triggers_rebuild(synth_graph, monkeypatch):
+    import api.mcp.tools.structural as S
+    from api.graph import AsyncGraphQuery
+
+    name, project, branch = synth_graph
+    calls = _spy_build(monkeypatch)
+
+    g = AsyncGraphQuery(name)
+    try:
+        await S._hybrid_rank(g, "parse tokens", project)
+        assert calls["n"] == 1
+
+        # Mutate the graph: a new File changes node count -> signature changes.
+        await g._query("CREATE (:File {path:'/root/proj/gamma.py'})")
+
+        results = await S._hybrid_rank(g, "gamma", project)
+    finally:
+        await g.close()
+
+    assert calls["n"] == 2, "node-count change must invalidate the cached corpus"
+    assert any("gamma.py" in r["file"] for r in results), results
+
+
+async def test_reset_corpus_cache_forces_rebuild(synth_graph, monkeypatch):
+    import api.mcp.tools.structural as S
+    from api.graph import AsyncGraphQuery
+
+    name, project, branch = synth_graph
+    calls = _spy_build(monkeypatch)
+
+    g = AsyncGraphQuery(name)
+    try:
+        await S._hybrid_rank(g, "parse tokens", project)
+        assert calls["n"] == 1
+
+        S.reset_corpus_cache(name)
+        await S._hybrid_rank(g, "parse tokens", project)
+    finally:
+        await g.close()
+
+    assert calls["n"] == 2, "explicit reset (index_repo hook) must force a rebuild"
+
+
+async def test_reset_all_clears_every_graph(synth_graph, monkeypatch):
+    import api.mcp.tools.structural as S
+    from api.graph import AsyncGraphQuery
+
+    name, project, branch = synth_graph
+    calls = _spy_build(monkeypatch)
+
+    g = AsyncGraphQuery(name)
+    try:
+        await S._hybrid_rank(g, "parse tokens", project)
+        assert calls["n"] == 1
+        assert len(S._CORPUS_CACHE) == 1
+
+        S.reset_corpus_cache()  # graph_name=None -> clear everything
+        assert len(S._CORPUS_CACHE) == 0
+
+        await S._hybrid_rank(g, "parse tokens", project)
+    finally:
+        await g.close()
+
+    assert calls["n"] == 2
+
+
+async def test_concurrent_first_calls_build_once(synth_graph, monkeypatch):
+    import asyncio
+
+    import api.mcp.tools.structural as S
+    from api.graph import AsyncGraphQuery
+
+    name, project, branch = synth_graph
+    calls = _spy_build(monkeypatch)
+
+    async def one():
+        g = AsyncGraphQuery(name)
+        try:
+            return await S._hybrid_rank(g, "parse tokens", project)
+        finally:
+            await g.close()
+
+    results = await asyncio.gather(*[one() for _ in range(5)])
+
+    assert calls["n"] == 1, "per-key lock must collapse concurrent cold builds to one"
+    assert all(r == results[0] for r in results)
+
+
+async def test_mutation_during_build_is_not_cached(synth_graph, monkeypatch):
+    """A graph that changes across the reads must not be stored (torn snapshot)."""
+    import api.mcp.tools.structural as S
+    from api.graph import AsyncGraphQuery
+
+    name, project, branch = synth_graph
+
+    g_probe = AsyncGraphQuery(name)
+    orig = S._build_corpus
+
+    async def mutate_then_build(g, project):
+        # Simulate a concurrent writer landing between the pre- and post-build
+        # signature probes by mutating the graph inside the build.
+        corpus = await orig(g, project)
+        await g_probe._query("CREATE (:File {path:'/root/proj/delta.py'})")
+        return corpus
+
+    monkeypatch.setattr(S, "_build_corpus", mutate_then_build)
+
+    g = AsyncGraphQuery(name)
+    try:
+        await S._hybrid_rank(g, "parse tokens", project)
+    finally:
+        await g.close()
+        await g_probe.close()
+
+    assert len(S._CORPUS_CACHE) == 0, "torn (mid-build mutation) corpus must not persist"

--- a/tests/mcp/test_snippet_guard.py
+++ b/tests/mcp/test_snippet_guard.py
@@ -1,0 +1,77 @@
+"""Symlink-safe guard for snippet file reads (PR #701 security review).
+
+``search_code`` / ``get_file_neighbors`` attach a short source snippet read
+from the indexed ``File.path``. Those paths ultimately come from repo content,
+so a malicious repo could store (or symlink) a path resolving outside the
+indexed worktree and turn a snippet read into an arbitrary host-file read.
+``_read_snippet`` now resolves the real path and only reads inside an allowed
+root (the ``/<project>/`` repo root and/or ``ALLOWED_ANALYSIS_DIR``).
+
+These tests are pure-Python (real temp files + a symlink); no FalkorDB needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from api.mcp.tools.structural import _is_within, _read_snippet, _snippet_path_allowed
+
+
+def _make_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Create ``<root>/proj/pkg/mod.py`` and an escaping symlink. Returns
+    ``(real_file, escaping_symlink, secret_outside)``."""
+    proj = tmp_path / "root" / "proj"
+    (proj / "pkg").mkdir(parents=True)
+    real_file = proj / "pkg" / "mod.py"
+    real_file.write_text("def alpha():\n    return 1\n\n\nx = 2\n")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("TOP SECRET LINE 1\nTOP SECRET LINE 2\n")
+
+    evil = proj / "evil.py"
+    evil.symlink_to(secret)
+    return real_file, evil, secret
+
+
+def test_reads_file_inside_repo_root(tmp_path: Path):
+    real_file, _evil, _secret = _make_repo(tmp_path)
+    snip = _read_snippet(str(real_file), 1, 3, 5, project="proj")
+    assert snip is not None
+    assert "def alpha" in snip
+
+
+def test_blocks_symlink_escaping_repo_root(tmp_path: Path):
+    _real_file, evil, _secret = _make_repo(tmp_path)
+    # The path lives under /proj/ but resolves (via symlink) outside the repo.
+    assert _snippet_path_allowed(str(evil), "proj") is False
+    assert _read_snippet(str(evil), 1, 2, 5, project="proj") is None
+
+
+def test_blocks_outside_path_when_allowed_dir_set(tmp_path: Path, monkeypatch):
+    _real_file, _evil, secret = _make_repo(tmp_path)
+    monkeypatch.setenv("ALLOWED_ANALYSIS_DIR", str(tmp_path / "root"))
+    # No /proj/ marker in this path, but ALLOWED_ANALYSIS_DIR excludes it.
+    assert _snippet_path_allowed(str(secret), None) is False
+    assert _read_snippet(str(secret), 1, 2, 5) is None
+
+
+def test_allows_when_no_constraint_derivable(tmp_path: Path):
+    # No project marker in the path and no ALLOWED_ANALYSIS_DIR -> legacy read.
+    f = tmp_path / "loose.py"
+    f.write_text("def beta():\n    return 0\n")
+    assert _snippet_path_allowed(str(f), None) is True
+    assert _read_snippet(str(f), 1, 2, 5) is not None
+
+
+def test_is_within_rejects_sibling_prefix(tmp_path: Path):
+    root = str(tmp_path / "proj")
+    # A sibling dir sharing a string prefix must NOT count as contained.
+    assert _is_within(str(tmp_path / "proj-evil" / "x.py"), root) is False
+    assert _is_within(str(tmp_path / "proj" / "x.py"), root) is True
+
+
+def test_missing_path_returns_none():
+    assert _read_snippet(None, 1, 2, 5, project="proj") is None
+    assert _read_snippet("", 1, 2, 5, project="proj") is None


### PR DESCRIPTION
## Prerequisites (merge order)

This branch is the **confluence of two stacks** — both must merge before this one.

**Analyzer stack (edge data the centrality ranker needs):**
1. #690 — `TreeSitterAnalyzer` base class (T15)
2. #691 — tree-sitter Python resolver (T18)
3. #698 — IMPORTS/OVERRIDES edges + resolver name→def fix

**MCP tools stack (the file this PR rewrites):**
4. #678 — `index_repo` (T4)
5. #679 — query tools incl. `find_path` + query helpers (T5/T7/T8)
6. #680 — `impact_analysis` (T6)
7. #681 — GraphRAG `ask` (T9/T10/T11)

GitHub base is pinned to **#681** (smallest diff); **#698 is an equal prerequisite** and shows in the diff as a confluence-merge artifact. `#692` (query-cache) is *not* required.

---

**Stacked draft — part of the benchmark-validated MCP navigation rewrite.**

Replaces the name-prefix `search_code` (#679) with a hybrid ranker (name-exact + path-overlap + BM25 over body/doc + log in-degree centrality − test/legacy penalty), and adds:
- `get_neighbors` (consolidates the per-verb get_callers/callees/dependencies/importers/overrides into one tool; legacy verbs retained as imported helpers for #695/#696 + tests)
- `get_file_neighbors` (file-level 1-hop expansion: union all symbols in a file, dedupe coupled files, return ranked candidate set)

### Stacking
Base is set to `#681` (T9–T11 ask) to keep the diff small. This branch was built on the **confluence of #681 and #698** (analyzer IMPORTS/OVERRIDES edges + resolver name→def fix), so **#698 is also a prerequisite** and its edge-data changes appear in this diff as a merge artifact. The hybrid ranker's centrality term depends on those IMPORTS/OVERRIDES edges.

Supersedes #679's `search_code` as a normal stacked improvement.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Free-text hybrid-ranking code search with richer relevance signals.
  * Unified neighbor traversal supporting multiple relation types/directions.
  * File-level neighbor discovery returning representative symbol snippets.

* **Improvements**
  * Results show project-relative file paths and on-demand snippets with safer path handling.
  * Search corpus cache with explicit invalidation after indexing; consolidated query surface advertised.

* **Tests**
  * New/expanded suites for search caching, snippet safety, neighbor behavior, and impact-analysis helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->