### PR TITLE
feat(mcp): find_symbol resolver + drop GraphRAG ask from MCP surface

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,15 @@
 FALKORDB_HOST=localhost
 FALKORDB_PORT=6379
 
+# Database backend. Use "lite" to run against an embedded FalkorDBLite
+# instance instead of an external FalkorDB host/port.
+CODE_GRAPH_DB_BACKEND=falkordb
+FALKORDB_LITE_PATH=~/.cache/code-graph/falkordblite.rdb
+# Optional: expose FalkorDBLite on localhost for host/port-only integrations
+# such as GraphRAG chat. Structural CodeGraph/MCP tools do not need this.
+# FALKORDB_LITE_HOST=127.0.0.1
+# FALKORDB_LITE_PORT=6379
+
 # Optional FalkorDB authentication
 FALKORDB_USERNAME=
 FALKORDB_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ code-graph/
 - Python `>=3.12,<3.14`
 - Node.js 20+
 - [`uv`](https://docs.astral.sh/uv/)
-- A FalkorDB instance (local or cloud)
+- A FalkorDB instance (local/cloud) or the optional FalkorDBLite backend
 
 ### 1. Start FalkorDB
 
@@ -68,6 +68,16 @@ code-graph/
 docker run -p 6379:6379 -it --rm falkordb/falkordb
 ```
 
+**Option C:** Use embedded FalkorDBLite:
+
+```bash
+uv sync --extra light
+export CODE_GRAPH_DB_BACKEND=lite
+export FALKORDB_LITE_PATH=~/.cache/code-graph/falkordblite.rdb
+```
+
+FalkorDBLite runs a local embedded server over a private Unix socket by default. Set `FALKORDB_LITE_PORT` only when a host/port-only integration, such as GraphRAG chat, must connect to the embedded database.
+
 ### 2. Configure environment variables
 
 Copy the template and adjust it for your setup:
@@ -78,10 +88,14 @@ cp .env.template .env
 
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
+| `CODE_GRAPH_DB_BACKEND` | Database backend: `falkordb` or `lite` | No | `falkordb` |
 | `FALKORDB_HOST` | FalkorDB hostname | No | `localhost` |
 | `FALKORDB_PORT` | FalkorDB port | No | `6379` |
 | `FALKORDB_USERNAME` | Optional FalkorDB username | No | empty |
 | `FALKORDB_PASSWORD` | Optional FalkorDB password | No | empty |
+| `FALKORDB_LITE_PATH` | FalkorDBLite database file path | No | `~/.cache/code-graph/falkordblite.rdb` |
+| `FALKORDB_LITE_HOST` | Host used when exposing FalkorDBLite over TCP | No | `127.0.0.1` |
+| `FALKORDB_LITE_PORT` | Optional TCP port for FalkorDBLite host/port clients | No | empty |
 | `SECRET_TOKEN` | Token checked by protected endpoints | No | empty |
 | `CODE_GRAPH_PUBLIC` | Set `1` to skip auth on read-only endpoints | No | `0` |
 | `ALLOWED_ANALYSIS_DIR` | Root path allowed for `/api/analyze_folder` | No | repository root |

--- a/api/cli.py
+++ b/api/cli.py
@@ -62,6 +62,18 @@ def _check_connection(host: str, port: int) -> bool:
 def ensure_db() -> None:
     """Ensure FalkorDB is running, auto-starting a Docker container if needed."""
 
+    from .db import create_falkordb, is_lite_backend
+
+    if is_lite_backend():
+        try:
+            db = create_falkordb()
+            db.connection.ping()
+        except Exception as e:
+            _json_error(f"Failed to initialize FalkorDBLite: {e}")
+        _stderr("FalkorDBLite embedded backend is ready")
+        _json_out({"status": "ok", "backend": "lite"})
+        return
+
     host = os.getenv("FALKORDB_HOST", "localhost")
     try:
         port = int(os.getenv("FALKORDB_PORT", "6379"))

--- a/api/db.py
+++ b/api/db.py
@@ -1,0 +1,157 @@
+"""Database backend selection for CodeGraph.
+
+The default backend is a regular FalkorDB server addressed by host/port.
+Set ``CODE_GRAPH_DB_BACKEND=lite`` to use FalkorDBLite's embedded server.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+LITE_BACKENDS = {"lite", "falkordblite"}
+DEFAULT_LITE_PATH = "~/.cache/code-graph/falkordblite.rdb"
+
+
+def is_lite_backend() -> bool:
+    """Return whether CodeGraph should use the embedded FalkorDBLite backend."""
+    backend = os.getenv("CODE_GRAPH_DB_BACKEND", "falkordb").strip().lower()
+    return backend in LITE_BACKENDS
+
+
+def _lite_db_path() -> str:
+    path = Path(os.getenv("FALKORDB_LITE_PATH", DEFAULT_LITE_PATH)).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return str(path)
+
+
+def _lite_serverconfig() -> dict[str, str]:
+    """Return FalkorDBLite server config from env.
+
+    FalkorDBLite defaults to a private Unix socket. Supplying
+    ``FALKORDB_LITE_PORT`` additionally exposes a local TCP port, which is
+    useful for libraries that only accept host/port connection settings.
+    """
+    port = os.getenv("FALKORDB_LITE_PORT")
+    if not port:
+        return {}
+    return {
+        "bind": os.getenv("FALKORDB_LITE_HOST", "127.0.0.1"),
+        "port": port,
+    }
+
+
+def create_falkordb() -> Any:
+    """Create a sync FalkorDB client for the configured backend."""
+    if is_lite_backend():
+        try:
+            from redislite.falkordb_client import FalkorDB as LiteFalkorDB
+        except ImportError as e:
+            raise RuntimeError(
+                "CODE_GRAPH_DB_BACKEND=lite requires the optional "
+                "`falkordblite` dependency. Install with "
+                "`uv sync --extra light` or `pip install 'falkordb-code-graph[light]'`."
+            ) from e
+
+        return LiteFalkorDB(_lite_db_path(), serverconfig=_lite_serverconfig())
+
+    from falkordb import FalkorDB
+
+    return FalkorDB(
+        host=os.getenv("FALKORDB_HOST", "localhost"),
+        port=os.getenv("FALKORDB_PORT", 6379),
+        username=os.getenv("FALKORDB_USERNAME", None),
+        password=os.getenv("FALKORDB_PASSWORD", None),
+    )
+
+
+def create_async_falkordb() -> Any:
+    """Create an async FalkorDB client for the configured backend."""
+    if is_lite_backend():
+        try:
+            from redislite.async_falkordb_client import AsyncFalkorDB as LiteAsyncFalkorDB
+        except ImportError as e:
+            raise RuntimeError(
+                "CODE_GRAPH_DB_BACKEND=lite requires the optional "
+                "`falkordblite` dependency. Install with "
+                "`uv sync --extra light` or `pip install 'falkordb-code-graph[light]'`."
+            ) from e
+
+        client = LiteAsyncFalkorDB(_lite_db_path(), serverconfig=_lite_serverconfig())
+        if not hasattr(client, "aclose"):
+            client.aclose = client.close
+        return client
+
+    from falkordb.asyncio import FalkorDB as AsyncFalkorDB
+
+    return AsyncFalkorDB(
+        host=os.getenv("FALKORDB_HOST", "localhost"),
+        port=int(os.getenv("FALKORDB_PORT", 6379)),
+        username=os.getenv("FALKORDB_USERNAME", None),
+        password=os.getenv("FALKORDB_PASSWORD", None),
+    )
+
+
+def create_redis_connection() -> Any:
+    """Create a sync Redis-compatible connection for metadata operations."""
+    if is_lite_backend():
+        return create_falkordb().connection
+
+    import redis
+
+    return redis.Redis(
+        host=os.getenv("FALKORDB_HOST", "localhost"),
+        port=int(os.getenv("FALKORDB_PORT", "6379")),
+        username=os.getenv("FALKORDB_USERNAME"),
+        password=os.getenv("FALKORDB_PASSWORD"),
+        decode_responses=True,
+    )
+
+
+def create_async_redis_connection() -> Any:
+    """Create an async Redis-compatible connection for metadata operations."""
+    if is_lite_backend():
+        return create_async_falkordb().connection
+
+    import redis.asyncio as aioredis
+
+    return aioredis.Redis(
+        host=os.getenv("FALKORDB_HOST", "localhost"),
+        port=int(os.getenv("FALKORDB_PORT", "6379")),
+        username=os.getenv("FALKORDB_USERNAME"),
+        password=os.getenv("FALKORDB_PASSWORD"),
+        decode_responses=True,
+    )
+
+
+def graphrag_connection_kwargs() -> dict[str, Any]:
+    """Return host/port kwargs for GraphRAG SDK constructors.
+
+    GraphRAG SDK accepts host/port only. FalkorDBLite's private Unix socket is
+    therefore usable for structural tools but not for GraphRAG unless a local
+    TCP port is explicitly enabled with ``FALKORDB_LITE_PORT``.
+    """
+    if is_lite_backend():
+        port = os.getenv("FALKORDB_LITE_PORT")
+        if not port:
+            raise RuntimeError(
+                "GraphRAG requires host/port access. When using "
+                "CODE_GRAPH_DB_BACKEND=lite, set FALKORDB_LITE_PORT to expose "
+                "the embedded FalkorDBLite instance on localhost."
+            )
+        create_falkordb()
+        return {
+            "host": os.getenv("FALKORDB_LITE_HOST", "127.0.0.1"),
+            "port": int(port),
+            "username": None,
+            "password": None,
+        }
+
+    return {
+        "host": os.getenv("FALKORDB_HOST", "localhost"),
+        "port": int(os.getenv("FALKORDB_PORT", 6379)),
+        "username": os.getenv("FALKORDB_USERNAME", None),
+        "password": os.getenv("FALKORDB_PASSWORD", None),
+    }

--- a/api/git_utils/git_graph.py
+++ b/api/git_utils/git_graph.py
@@ -1,9 +1,8 @@
-import os
 import logging
-from falkordb import FalkorDB, Node
-from falkordb.asyncio import FalkorDB as AsyncFalkorDB
+from falkordb import Node
 from typing import List, Optional
 
+from api.db import create_async_falkordb, create_falkordb
 from pygit2 import Commit
 
 # Configure logging
@@ -19,10 +18,7 @@ class GitGraph():
 
     def __init__(self, name: str):
 
-        self.db = FalkorDB(host=os.getenv('FALKORDB_HOST', 'localhost'),
-                           port=os.getenv('FALKORDB_PORT', 6379),
-                           username=os.getenv('FALKORDB_USERNAME', None),
-                           password=os.getenv('FALKORDB_PASSWORD', None))
+        self.db = create_falkordb()
 
         self.g = self.db.select_graph(name)
 
@@ -182,12 +178,7 @@ class AsyncGitGraph:
     """Async read-only git graph for endpoint use."""
 
     def __init__(self, name: str):
-        self.db = AsyncFalkorDB(
-            host=os.getenv('FALKORDB_HOST', 'localhost'),
-            port=int(os.getenv('FALKORDB_PORT', 6379)),
-            username=os.getenv('FALKORDB_USERNAME', None),
-            password=os.getenv('FALKORDB_PASSWORD', None),
-        )
+        self.db = create_async_falkordb()
         self.g = self.db.select_graph(name)
 
     def _commit_from_node(self, node: Node) -> dict:
@@ -205,4 +196,3 @@ class AsyncGitGraph:
 
     async def close(self) -> None:
         await self.db.aclose()
-

--- a/api/graph.py
+++ b/api/graph.py
@@ -1,10 +1,9 @@
-import os
 import re
 import time
-from .entities import *
 from typing import Optional
-from falkordb import FalkorDB, Path, Node, QueryResult
-from falkordb.asyncio import FalkorDB as AsyncFalkorDB
+from falkordb import Path, Node, QueryResult
+from .db import create_async_falkordb, create_falkordb
+from .entities import File, encode_edge, encode_node
 
 # Configure the logger
 import logging
@@ -62,10 +61,7 @@ def parse_graph_name(graph_name: str) -> Optional[tuple[str, str]]:
 
 
 def graph_exists(name: str):
-    db = FalkorDB(host=os.getenv('FALKORDB_HOST', 'localhost'),
-                  port=os.getenv('FALKORDB_PORT', 6379),
-                  username=os.getenv('FALKORDB_USERNAME', None),
-                  password=os.getenv('FALKORDB_PASSWORD', None))
+    db = create_falkordb()
 
     return name in db.list_graphs()
 
@@ -86,10 +82,7 @@ def get_repos() -> list[dict]:
         single graph until the migration is run.
     """
 
-    db = FalkorDB(host=os.getenv('FALKORDB_HOST', 'localhost'),
-                  port=os.getenv('FALKORDB_PORT', 6379),
-                  username=os.getenv('FALKORDB_USERNAME', None),
-                  password=os.getenv('FALKORDB_PASSWORD', None))
+    db = create_falkordb()
 
     repos = []
     for g in db.list_graphs():
@@ -140,10 +133,7 @@ class Graph():
             self.branch = branch or DEFAULT_BRANCH
             self.name = compose_graph_name(self.project, self.branch)
 
-        self.db = FalkorDB(host=os.getenv('FALKORDB_HOST', 'localhost'),
-                           port=os.getenv('FALKORDB_PORT', 6379),
-                           username=os.getenv('FALKORDB_USERNAME', None),
-                           password=os.getenv('FALKORDB_PASSWORD', None))
+        self.db = create_falkordb()
         self.g = self.db.select_graph(self.name)
 
         # Initialize the backlog as disabled by default
@@ -180,10 +170,7 @@ class Graph():
             obj.branch = DEFAULT_BRANCH
         else:
             obj.project, obj.branch = parsed
-        obj.db = FalkorDB(host=os.getenv('FALKORDB_HOST', 'localhost'),
-                          port=os.getenv('FALKORDB_PORT', 6379),
-                          username=os.getenv('FALKORDB_USERNAME', None),
-                          password=os.getenv('FALKORDB_PASSWORD', None))
+        obj.db = create_falkordb()
         obj.g = obj.db.select_graph(raw_name)
         obj.backlog = None
         return obj
@@ -297,7 +284,7 @@ class Graph():
 
         return result_set
 
-    def get_sub_graph(self, l: int) -> dict:
+    def get_sub_graph(self, limit: int) -> dict:
 
         q = """MATCH (src)
                    OPTIONAL MATCH (src)-[e]->(dest)
@@ -306,7 +293,7 @@ class Graph():
 
         sub_graph = {'nodes': [], 'edges': [] }
 
-        result_set = self._query(q, {'limit': l}).result_set
+        result_set = self._query(q, {'limit': limit}).result_set
         for row in result_set:
             src  = row[0]
             e    = row[1]
@@ -592,7 +579,7 @@ class Graph():
 
         params = {'path': path, 'name': name, 'ext': ext, 'coverage': coverage}
 
-        res = self._query(q, params)
+        self._query(q, params)
 
     def connect_entities(self, relation: str, src_id: int, dest_id: int, properties: dict = {}) -> None:
         """
@@ -789,14 +776,9 @@ class Graph():
 # Async helpers and read-only async graph wrapper
 # ---------------------------------------------------------------------------
 
-def _async_db() -> AsyncFalkorDB:
+def _async_db():
     """Create an async FalkorDB connection using environment config."""
-    return AsyncFalkorDB(
-        host=os.getenv('FALKORDB_HOST', 'localhost'),
-        port=int(os.getenv('FALKORDB_PORT', 6379)),
-        username=os.getenv('FALKORDB_USERNAME', None),
-        password=os.getenv('FALKORDB_PASSWORD', None),
-    )
+    return create_async_falkordb()
 
 
 async def async_graph_exists(name: str) -> bool:
@@ -952,4 +934,3 @@ class AsyncGraphQuery:
 
     async def close(self) -> None:
         await self.db.aclose()
-

--- a/api/info.py
+++ b/api/info.py
@@ -1,9 +1,9 @@
-import os
 import redis
 import redis.asyncio as aioredis
 import logging
 from typing import Optional, Dict
 
+from .db import create_async_redis_connection, create_redis_connection
 from .graph import DEFAULT_BRANCH
 
 # Configure logging
@@ -39,13 +39,7 @@ def get_redis_connection() -> redis.Redis:
         redis.Redis: A Redis connection object.
     """
     try:
-        return redis.Redis(
-            host             = os.getenv('FALKORDB_HOST', "localhost"),
-            port             = int(os.getenv('FALKORDB_PORT', "6379")),
-            username         = os.getenv('FALKORDB_USERNAME'),
-            password         = os.getenv('FALKORDB_PASSWORD'),
-            decode_responses = True  # To ensure string responses
-        )
+        return create_redis_connection()
     except Exception as e:
         logging.error(f"Error connecting to Redis: {e}")
         raise
@@ -160,13 +154,7 @@ def get_repo_info(repo_name: str, branch: Optional[str] = None) -> Optional[Dict
 # ---------------------------------------------------------------------------
 
 async def async_get_redis_connection() -> aioredis.Redis:
-    return aioredis.Redis(
-        host=os.getenv('FALKORDB_HOST', "localhost"),
-        port=int(os.getenv('FALKORDB_PORT', "6379")),
-        username=os.getenv('FALKORDB_USERNAME'),
-        password=os.getenv('FALKORDB_PASSWORD'),
-        decode_responses=True,
-    )
+    return create_async_redis_connection()
 
 
 async def async_get_repo_info(repo_name: str, branch: Optional[str] = None) -> Optional[Dict[str, str]]:
@@ -187,4 +175,3 @@ async def async_get_repo_info(repo_name: str, branch: Optional[str] = None) -> O
     except Exception as e:
         logging.error(f"Error retrieving repo info for '{repo_name}': {e}")
         raise
-

--- a/api/llm.py
+++ b/api/llm.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 from typing import Optional
 
+from .db import graphrag_connection_kwargs
 from graphrag_sdk.models.litellm import LiteModel
 from graphrag_sdk import (
     Ontology,
@@ -255,10 +256,7 @@ def _create_kg_agent(repo_name: str, branch: Optional[str] = None):
         name=graph_name,
         ontology=ontology,
         model_config=KnowledgeGraphModelConfig.with_model(model),
-        host=os.getenv('FALKORDB_HOST', 'localhost'),
-        port=os.getenv('FALKORDB_PORT', 6379),
-        username=os.getenv('FALKORDB_USERNAME', None),
-        password=os.getenv('FALKORDB_PASSWORD', None),
+        **graphrag_connection_kwargs(),
         cypher_system_instruction=CYPHER_GEN_SYSTEM,
         qa_system_instruction=GRAPH_QA_SYSTEM,
         cypher_gen_prompt=CYPHER_GEN_PROMPT,

--- a/api/mcp/tools/__init__.py
+++ b/api/mcp/tools/__init__.py
@@ -4,4 +4,11 @@ Each submodule registers tools against the shared FastMCP app exposed by
 ``api.mcp.server``. Import this package to register all tools.
 """
 
+# NOTE: the GraphRAG-backed ``ask`` tool is intentionally NOT part of the MCP
+# surface. In benchmarking it failed on every call ("Missing GOOGLE_API_KEY/
+# GEMINI_API_KEY") because the spawned MCP server env carries only FalkorDB
+# coordinates, and even when keyed it returned File-level fuzzy matches rather
+# than the structural answers the nav workflow needs. Burning an LLM round-trip
+# per call for no signal, so we expose only the deterministic structural tools.
+# GraphRAG ask remains available on the HTTP /api/chat path.
 from . import structural  # noqa: F401  (registers tools on import)

--- a/api/mcp/tools/structural.py
+++ b/api/mcp/tools/structural.py
@@ -735,6 +735,82 @@ async def _neighbors_payload(
         await g.close()
 
 
+FIND_SYMBOL_SNIPPET_LINES = 4
+FIND_SYMBOL_DB_LIMIT = 200
+
+
+@app.tool(
+    name="find_symbol",
+    description=(
+        "Resolve a Function/Class NAME to its integer symbol node id — the "
+        "bridge from a human-readable name to the `symbol_id` that "
+        "`get_neighbors`, `impact_analysis` and `find_path` require (those tools "
+        "take an id, NOT a name; `search_code` returns FILES, not symbol ids, so "
+        "start here for relationship questions). Pass the simple name "
+        "(e.g. `normalize_cartesian_coordinates`); a dotted qualname "
+        "(`Grid.normalize_cartesian_coordinates`) is accepted and its last "
+        "segment is used. Optionally pass `file` (repo-relative path or a "
+        "substring of it) to disambiguate same-named symbols — matches in that "
+        "file are flagged `file_match: true` and listed first. Returns "
+        "[{symbol_id, name, label, file, line, file_match, snippet}] ordered "
+        "best-scoped first; when more than one remains, disambiguate by `file` "
+        "and `snippet`. Feed the chosen `symbol_id` to the relationship tools."
+    ),
+)
+async def find_symbol(
+    name: str,
+    project: str,
+    file: Optional[str] = None,
+    branch: Optional[str] = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Look up Function/Class nodes by their simple name.
+
+    Symbol nodes store only the SIMPLE name (``foo``), never the qualname
+    (``Bar.foo``), so a dotted input is reduced to its last segment. When
+    ``file`` is given we do not silently widen the search: every candidate is
+    tagged ``file_match`` and the in-file ones sort first, so a wrong/empty
+    file filter degrades visibly (the agent still sees the global matches but
+    knows none were in the requested file) rather than routing a relationship
+    query to an arbitrary same-named symbol.
+    """
+    simple = str(name).strip().split(".")[-1]
+    g = _project_arg(project, branch)
+    try:
+        res = await g._query(
+            "MATCH (n) WHERE (n:Function OR n:Class) AND n.name = $name "
+            "RETURN n LIMIT $limit",
+            {"name": simple, "limit": FIND_SYMBOL_DB_LIMIT},
+        )
+        rows = [
+            _node_summary(
+                r[0],
+                rel_to=project,
+                snippet_lines=FIND_SYMBOL_SNIPPET_LINES,
+            )
+            for r in res.result_set
+        ]
+    finally:
+        await g.close()
+
+    for r in rows:
+        r["symbol_id"] = r.pop("id")
+
+    if file is not None:
+        needle = str(file).strip().lstrip("/")
+
+        def _matches(r: dict[str, Any]) -> bool:
+            fp = r.get("file") or ""
+            return bool(needle) and (fp == needle or fp.endswith(needle) or needle in fp)
+
+        for r in rows:
+            r["file_match"] = _matches(r)
+        # In-file matches first; preserve relative order within each group.
+        rows.sort(key=lambda r: not r["file_match"])
+
+    return rows[:limit]
+
+
 @app.tool(
     name="get_neighbors",
     description=(

--- a/api/mcp/tools/structural.py
+++ b/api/mcp/tools/structural.py
@@ -739,6 +739,27 @@ FIND_SYMBOL_SNIPPET_LINES = 4
 FIND_SYMBOL_DB_LIMIT = 200
 
 
+def _clamp_find_symbol_limit(limit: Any) -> int:
+    """Coerce ``limit`` to ``1..FIND_SYMBOL_DB_LIMIT``.
+
+    Agents may hand back a stringified or out-of-range ``limit``; a negative
+    value would otherwise flip ``rows[:limit]`` into a surprising tail slice and
+    a non-integer would fail deep in the slice with an opaque error. Strings of
+    digits are accepted; anything else is rejected up front.
+    """
+    if isinstance(limit, bool):
+        raise ValueError(f"limit must be an integer, got bool: {limit!r}")
+    if isinstance(limit, str) and limit.lstrip("-").isdigit():
+        limit = int(limit)
+    if not isinstance(limit, int):
+        raise ValueError(f"limit must be an integer, got: {limit!r}")
+    if limit < 1:
+        return 1
+    if limit > FIND_SYMBOL_DB_LIMIT:
+        return FIND_SYMBOL_DB_LIMIT
+    return limit
+
+
 @app.tool(
     name="find_symbol",
     description=(
@@ -767,14 +788,20 @@ async def find_symbol(
     """Look up Function/Class nodes by their simple name.
 
     Symbol nodes store only the SIMPLE name (``foo``), never the qualname
-    (``Bar.foo``), so a dotted input is reduced to its last segment. When
-    ``file`` is given we do not silently widen the search: every candidate is
-    tagged ``file_match`` and the in-file ones sort first, so a wrong/empty
-    file filter degrades visibly (the agent still sees the global matches but
-    knows none were in the requested file) rather than routing a relationship
-    query to an arbitrary same-named symbol.
+    (``Bar.foo``), so a dotted input is reduced to its last segment. Every
+    candidate carries a ``file_match`` flag (always ``False`` when no ``file``
+    filter is requested); when ``file`` is given we do not silently widen the
+    search — the in-file ones sort first, so a wrong/empty file filter degrades
+    visibly (the agent still sees the global matches but knows none were in the
+    requested file) rather than routing a relationship query to an arbitrary
+    same-named symbol.
     """
-    simple = str(name).strip().split(".")[-1]
+    simple = str(name).strip().split(".")[-1].strip()
+    if not simple:
+        raise ValueError(
+            f"name must be a non-empty symbol name, got: {name!r}"
+        )
+    eff_limit = _clamp_find_symbol_limit(limit)
     g = _project_arg(project, branch)
     try:
         res = await g._query(
@@ -796,19 +823,28 @@ async def find_symbol(
     for r in rows:
         r["symbol_id"] = r.pop("id")
 
-    if file is not None:
-        needle = str(file).strip().lstrip("/")
+    needle = str(file).strip().lstrip("/") if file is not None else ""
 
-        def _matches(r: dict[str, Any]) -> bool:
-            fp = r.get("file") or ""
-            return bool(needle) and (fp == needle or fp.endswith(needle) or needle in fp)
+    def _matches(r: dict[str, Any]) -> bool:
+        fp = r.get("file") or ""
+        return bool(needle) and (fp == needle or fp.endswith(needle) or needle in fp)
 
-        for r in rows:
-            r["file_match"] = _matches(r)
-        # In-file matches first; preserve relative order within each group.
-        rows.sort(key=lambda r: not r["file_match"])
+    # ``file_match`` is part of the documented response shape, so set it on
+    # every row (False when no ``file`` filter is requested) rather than only
+    # when ``file`` is given. Sort deterministically — in-file matches first,
+    # then by file/line/name/id — so ordering never depends on FalkorDB row
+    # order between runs.
+    for r in rows:
+        r["file_match"] = _matches(r)
+    rows.sort(key=lambda r: (
+        not r["file_match"],
+        r.get("file") or "",
+        r["line"] if r.get("line") is not None else math.inf,
+        r.get("name") or "",
+        r["symbol_id"],
+    ))
 
-    return rows[:limit]
+    return rows[:eff_limit]
 
 
 @app.tool(

--- a/api/migrations/per_branch.py
+++ b/api/migrations/per_branch.py
@@ -20,11 +20,11 @@ multiple times — already-migrated graphs are skipped — and exposes a
 from __future__ import annotations
 
 import logging
-import os
 from typing import Iterable
 
 from falkordb import FalkorDB
 
+from ..db import create_falkordb
 from ..graph import (
     DEFAULT_BRANCH,
     compose_graph_name,
@@ -37,12 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 def _connect() -> FalkorDB:
-    return FalkorDB(
-        host=os.getenv("FALKORDB_HOST", "localhost"),
-        port=os.getenv("FALKORDB_PORT", 6379),
-        username=os.getenv("FALKORDB_USERNAME", None),
-        password=os.getenv("FALKORDB_PASSWORD", None),
-    )
+    return create_falkordb()
 
 
 def _legacy_graphs(all_graphs: Iterable[str]) -> list[str]:

--- a/benchmarks/mcp_context_benchmark.py
+++ b/benchmarks/mcp_context_benchmark.py
@@ -1,0 +1,203 @@
+"""Estimate context/token savings from CodeGraph MCP-style lookups.
+
+This benchmark is intentionally deterministic: it does not call an LLM and
+does not require provider API keys. It compares the approximate context size an
+agent would send when answering 100 code-navigation questions in two modes:
+
+* graph: compact structured context from CodeGraph MCP tools
+* plain: raw source-file context from the likely file an agent would inspect
+
+Run after indexing the repo/folder, for example:
+
+    CODE_GRAPH_DB_BACKEND=lite FALKORDB_LITE_PATH=/tmp/code-graph-lite.rdb \
+      uv run --extra light cgraph index api --repo code-graph-api --branch local-test
+
+    CODE_GRAPH_DB_BACKEND=lite FALKORDB_LITE_PATH=/tmp/code-graph-lite.rdb \
+      uv run --extra light python benchmarks/mcp_context_benchmark.py \
+        --project code-graph-api --branch local-test --root api
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logging.disable(logging.CRITICAL)
+
+from api.mcp.tools.structural import find_symbol, get_file_neighbors, get_neighbors  # noqa: E402
+
+
+@dataclass(frozen=True)
+class Target:
+    subject: str
+    symbol: str
+    file: str
+
+
+@dataclass(frozen=True)
+class Question:
+    text: str
+    target: Target
+
+
+TARGETS = [
+    Target("Graph class ownership and methods", "Graph", "api/graph.py"),
+    Target("AsyncGraphQuery neighbor reads", "AsyncGraphQuery", "api/graph.py"),
+    Target("regular-vs-Lite backend selection", "create_falkordb", "api/db.py"),
+    Target("GraphRAG host/port configuration", "graphrag_connection_kwargs", "api/db.py"),
+    Target("MCP repository indexing", "index_repo", "api/mcp/tools/structural.py"),
+    Target("symbol resolution before traversal", "find_symbol", "api/mcp/tools/structural.py"),
+    Target("single-hop graph traversal", "get_neighbors", "api/mcp/tools/structural.py"),
+    Target("project source analysis orchestration", "Project", "api/project.py"),
+    Target("local folder analyzer pipeline", "SourceAnalyzer", "api/analyzers/source_analyzer.py"),
+    Target("C# analyzer restore behavior", "CSharpAnalyzer", "api/analyzers/csharp/analyzer.py"),
+]
+
+QUESTION_TEMPLATES = [
+    "What does {subject} do?",
+    "Which symbols are directly related to {subject}?",
+    "What would likely be impacted if {subject} changed?",
+    "Which callers or incoming relationships does {subject} have?",
+    "Which dependencies or outgoing relationships does {subject} have?",
+    "Where is {subject} defined and what is its local context?",
+    "What methods or child symbols does {subject} define?",
+    "How should an agent navigate from {subject} to related code?",
+    "What source file should be inspected for {subject}?",
+    "Summarize {subject} using only relevant structural context.",
+]
+
+QUESTIONS = [
+    Question(template.format(subject=target.subject), target)
+    for target in TARGETS
+    for template in QUESTION_TEMPLATES
+]
+
+
+def estimate_tokens(text: str) -> int:
+    """Cheap token approximation for relative comparisons."""
+    return max(1, len(text) // 4)
+
+
+def compact_json(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def read_plain_context(root: Path, file_hint: str) -> str:
+    path = root.parent / file_hint if file_hint.startswith(f"{root.name}/") else root / file_hint
+    if not path.exists():
+        path = root.parent / file_hint
+    return path.read_text(errors="replace")
+
+
+async def graph_context(question: Question, project: str, branch: str | None) -> dict[str, Any]:
+    symbols = await find_symbol(
+        name=question.target.symbol,
+        project=project,
+        branch=branch,
+        file=question.target.file,
+        limit=3,
+    )
+    payload: dict[str, Any] = {"symbols": symbols}
+    if not symbols:
+        return payload
+
+    symbol_id = symbols[0]["symbol_id"]
+    payload["defines_out"] = await get_neighbors(
+        symbol_id=symbol_id,
+        project=project,
+        branch=branch,
+        relation="DEFINES",
+        direction="OUT",
+        limit=30,
+    )
+    payload["calls_in"] = await get_neighbors(
+        symbol_id=symbol_id,
+        project=project,
+        branch=branch,
+        relation="CALLS",
+        direction="IN",
+        limit=15,
+    )
+    payload["calls_out"] = await get_neighbors(
+        symbol_id=symbol_id,
+        project=project,
+        branch=branch,
+        relation="CALLS",
+        direction="OUT",
+        limit=15,
+    )
+    payload["file_neighbors"] = await get_file_neighbors(
+        file=question.target.file,
+        project=project,
+        branch=branch,
+        limit=20,
+    )
+    return payload
+
+
+async def run(project: str, branch: str | None, root: Path) -> None:
+    rows = []
+    graph_total = 0
+    plain_total = 0
+    graph_contexts: dict[Target, str] = {}
+
+    for question in QUESTIONS:
+        if question.target not in graph_contexts:
+            graph_contexts[question.target] = compact_json(
+                await graph_context(question, project, branch)
+            )
+        graph_text = graph_contexts[question.target]
+        plain_text = read_plain_context(root, question.target.file)
+        graph_tokens = estimate_tokens(graph_text)
+        plain_tokens = estimate_tokens(plain_text)
+        graph_total += graph_tokens
+        plain_total += plain_tokens
+        rows.append(
+            {
+                "question": question.text,
+                "symbol": question.target.symbol,
+                "file": question.target.file,
+                "graph_tokens": graph_tokens,
+                "plain_tokens": plain_tokens,
+                "delta_tokens": plain_tokens - graph_tokens,
+                "reduction_pct": round((1 - graph_tokens / plain_tokens) * 100, 1)
+                if plain_tokens
+                else 0,
+            }
+        )
+
+    summary = {
+        "project": project,
+        "branch": branch,
+        "questions": len(QUESTIONS),
+        "graph_tokens": graph_total,
+        "plain_tokens": plain_total,
+        "delta_tokens": plain_total - graph_total,
+        "reduction_pct": round((1 - graph_total / plain_total) * 100, 1)
+        if plain_total
+        else 0,
+    }
+    print(json.dumps({"summary": summary, "rows": rows}, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", required=True, help="Indexed CodeGraph project name")
+    parser.add_argument("--branch", default=None, help="Indexed branch name")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("api"),
+        help="Source root used for the plain-context baseline",
+    )
+    args = parser.parse_args()
+    asyncio.run(run(args.project, args.branch, args.root.resolve()))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ cgraph = "api.cli:app"
 cgraph-mcp = "api.mcp.server:main"
 
 [project.optional-dependencies]
+light = [
+    "falkordblite>=0.10.0,<1.0.0",
+]
 test = [
     "pytest>=9.0.2,<10.0.0",
     "ruff>=0.11.0,<1.0.0",

--- a/tests/mcp/test_find_symbol.py
+++ b/tests/mcp/test_find_symbol.py
@@ -1,0 +1,221 @@
+"""T9 — find_symbol MCP tool tests.
+
+Covers name resolution (simple + dotted qualname reduction), the ``file``
+disambiguation flag + ordering, response-shape stability, deterministic order,
+and ``limit`` / empty-name validation.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+# ---------------------------------------------------------------------------
+# Validation — no FalkorDB required (these raise before touching the graph)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "Foo.", "Bar.   "])
+async def test_find_symbol_rejects_empty_name(bad):
+    from api.mcp.tools.structural import find_symbol
+
+    with pytest.raises(ValueError, match="non-empty symbol name"):
+        await find_symbol(name=bad, project="any")
+
+
+@pytest.mark.parametrize("bad", ["not-a-number", 1.5, None, True])
+async def test_find_symbol_rejects_garbage_limit(bad):
+    from api.mcp.tools.structural import find_symbol
+
+    with pytest.raises(ValueError, match="limit"):
+        await find_symbol(name="entrypoint", project="any", limit=bad)
+
+
+# ---------------------------------------------------------------------------
+# Integration — sample_project fixture
+# ---------------------------------------------------------------------------
+
+
+async def test_find_symbol_resolves_simple_name(indexed_fixture):
+    from api.mcp.tools.structural import find_symbol
+
+    rows = await find_symbol(
+        name="entrypoint",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    assert rows, "entrypoint must resolve"
+    r = rows[0]
+    assert isinstance(r["symbol_id"], int)
+    assert r["name"] == "entrypoint"
+    assert r["label"] == "Function"
+    assert r["file"].endswith("entrypoint.py")
+    assert isinstance(r["line"], int)
+    # file_match is part of the documented shape and present even without a
+    # ``file`` filter (False when none requested).
+    assert r["file_match"] is False
+
+
+async def test_find_symbol_reduces_dotted_qualname(indexed_fixture):
+    """``Class.method`` must resolve identically to the bare ``method``."""
+    from api.mcp.tools.structural import find_symbol
+
+    dotted = await find_symbol(
+        name="BaseRepo.repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    simple = await find_symbol(
+        name="repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    assert {r["symbol_id"] for r in dotted} == {r["symbol_id"] for r in simple}
+    assert all(r["name"] == "repo" for r in dotted)
+    # Fixture defines repo() on BaseRepo, UserRepo and OrderRepo.
+    assert len(simple) == 3
+
+
+async def test_find_symbol_file_match_shape_stable(indexed_fixture):
+    """Every row carries a boolean ``file_match`` regardless of the args."""
+    from api.mcp.tools.structural import find_symbol
+
+    rows = await find_symbol(
+        name="repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    assert rows
+    for r in rows:
+        assert isinstance(r["file_match"], bool)
+        assert set(r) >= {"symbol_id", "name", "label", "file", "line", "file_match"}
+
+
+async def test_find_symbol_file_filter_flags_matches(indexed_fixture):
+    """A matching ``file`` flags every in-file candidate; a non-matching one
+    still returns the global matches but flags none."""
+    from api.mcp.tools.structural import find_symbol
+
+    in_file = await find_symbol(
+        name="repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+        file="repo.py",
+    )
+    assert in_file and all(r["file_match"] for r in in_file)
+
+    no_file = await find_symbol(
+        name="repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+        file="does_not_exist.py",
+    )
+    # Search is not silently widened away — global matches still surface…
+    assert {r["symbol_id"] for r in no_file} == {r["symbol_id"] for r in in_file}
+    # …but the agent can see none were in the requested file.
+    assert all(r["file_match"] is False for r in no_file)
+
+
+async def test_find_symbol_deterministic_order(indexed_fixture):
+    """Repeated calls return rows in the same order (no FalkorDB row-order
+    dependence)."""
+    from api.mcp.tools.structural import find_symbol
+
+    a = await find_symbol(
+        name="repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    b = await find_symbol(
+        name="repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    assert [r["symbol_id"] for r in a] == [r["symbol_id"] for r in b]
+
+
+async def test_find_symbol_honors_limit(indexed_fixture):
+    from api.mcp.tools.structural import find_symbol
+
+    rows = await find_symbol(
+        name="repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+        limit="1",  # stringified ints are accepted and coerced
+    )
+    assert len(rows) == 1
+
+
+async def test_find_symbol_negative_limit_clamped_not_tail_slice(indexed_fixture):
+    """A negative ``limit`` must clamp to 1, NOT flip ``rows[:limit]`` into a
+    surprising tail slice."""
+    from api.mcp.tools.structural import find_symbol
+
+    full = await find_symbol(
+        name="repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+    )
+    clamped = await find_symbol(
+        name="repo",
+        project=indexed_fixture.project,
+        branch=indexed_fixture.branch,
+        limit=-2,
+    )
+    assert len(clamped) == 1
+    assert clamped[0]["symbol_id"] == full[0]["symbol_id"]
+
+
+async def test_find_symbol_registered():
+    from api.mcp.server import app
+
+    names = {t.name for t in await app.list_tools()}
+    assert "find_symbol" in names
+
+
+# ---------------------------------------------------------------------------
+# Ordering across files — purpose-built graph (two same-named symbols)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def two_file_graph():
+    """Two ``foo`` Functions in different files so ``file`` disambiguation can
+    actually reorder the result. Unique branch keeps it isolated; not torn down
+    (matches the ``indexed_fixture`` / ``cycle_graph`` pattern)."""
+    from api.graph import Graph
+
+    project = "find_symbol_order_test"
+    branch = f"order-{uuid.uuid4().hex[:8]}"
+    g = Graph(project, branch=branch)
+    g.g.query(
+        """
+        CREATE
+          (:Function:Searchable {name: 'foo', path: '/tmp/aaa.py', src_start: 1}),
+          (:Function:Searchable {name: 'foo', path: '/tmp/bbb.py', src_start: 1})
+        """
+    )
+    yield project, branch
+
+
+async def test_find_symbol_orders_in_file_first(two_file_graph):
+    from api.mcp.tools.structural import find_symbol
+
+    project, branch = two_file_graph
+
+    rows = await find_symbol(name="foo", project=project, branch=branch, file="bbb.py")
+    assert len(rows) == 2
+    # The requested file sorts first and is the only flagged match.
+    assert rows[0]["file"].endswith("bbb.py")
+    assert rows[0]["file_match"] is True
+    assert rows[1]["file_match"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <3.14"
 
 [[package]]
@@ -372,6 +372,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+light = [
+    { name = "falkordblite" },
+]
 test = [
     { name = "anyio" },
     { name = "httpx" },
@@ -391,6 +394,7 @@ requires-dist = [
     { name = "anyio", marker = "extra == 'test'", specifier = ">=4.0,<5.0" },
     { name = "falkordb", specifier = ">=1.1.3,<2.0.0" },
     { name = "falkordb-multilspy", specifier = ">=0.1.0,<1.0.0" },
+    { name = "falkordblite", marker = "extra == 'light'", specifier = ">=0.10.0,<1.0.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
     { name = "graphrag-sdk", specifier = ">=0.8.1,<0.9.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.28.0,<1.0.0" },
@@ -411,7 +415,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0,<1.0.0" },
     { name = "validators", specifier = ">=0.35.0,<0.36.0" },
 ]
-provides-extras = ["test"]
+provides-extras = ["light", "test"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -433,6 +437,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f0/4e/50ac939db4243dff2cf3ddd94cd75233b30f06470141cca09ed0d70a2f6c/falkordb_multilspy-0.1.0.tar.gz", hash = "sha256:779117d1b801322e30dc593d03da5eeda1d848209fc47d33534d3c9422a6f255", size = 115180, upload-time = "2026-03-23T14:29:34.639Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/15/97032c229a031b29795c2d0a74646bc24b1bdbb71930c44d1d37ef9d98c6/falkordb_multilspy-0.1.0-py3-none-any.whl", hash = "sha256:3429f11a83c4fbf06c2b8f0078b8a257e0870da9d50ebd964c6de2ad33164f57", size = 129555, upload-time = "2026-03-23T14:29:32.936Z" },
+]
+
+[[package]]
+name = "falkordblite"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "falkordb" },
+    { name = "psutil" },
+    { name = "redis" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/03/afbb6e0f03c302aa9b64a38e1a2c43664f86921f0dcbf03ec9e31da06ac6/falkordblite-0.10.0.tar.gz", hash = "sha256:65a72abafd30711f699c15571df6959edb8901605053ce940ccdd837832e709b", size = 23675620, upload-time = "2026-05-02T13:12:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/43/39d8cf13964784447676d24f0cefa3bdc99c10e647c71e6a4172d302dcac/falkordblite-0.10.0-cp312-cp312-macosx_10_13_x86_64.macosx_15_0_arm64.whl", hash = "sha256:741fda166170513db1815d5369870e47d44da2e9b85320fddbc50c88a7338d51", size = 17752268, upload-time = "2026-05-02T13:11:57.906Z" },
+    { url = "https://files.pythonhosted.org/packages/61/17/3ec180ca7c2e79a0c3e9912ac04b446e733745cd944845fe4306be016efd/falkordblite-0.10.0-cp312-cp312-manylinux_2_39_aarch64.whl", hash = "sha256:bfe1f47ae03decdc0ad111ec82606bac82ee6cdd7fea04cbcff1283608cc2d2e", size = 34579293, upload-time = "2026-05-02T13:12:01.601Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5e/d343c5249bd24c6614e8c1b718a73bb9f68beb2cf90464bc51c9436d25af/falkordblite-0.10.0-cp312-cp312-manylinux_2_39_x86_64.whl", hash = "sha256:ee9659bd0c7cdf0c2532977f2ec8bf1d1ab01cb3b6776e50c67046481f3162c7", size = 36154066, upload-time = "2026-05-02T13:12:05.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1e/18612dc9e75e5c02a281a49d97b56b5504eb5907f971c68e8a5801033f36/falkordblite-0.10.0-cp313-cp313-macosx_10_13_x86_64.macosx_15_0_arm64.whl", hash = "sha256:54a051cbc0bb25b30e65f46ddb1b63149a80bb7004c97615d39c491d492a6d9b", size = 17752240, upload-time = "2026-05-02T13:12:08.837Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b3/63f9b1168c4d1abbee4418a0a165496f57cd4b93a261cb481272ce353890/falkordblite-0.10.0-cp313-cp313-manylinux_2_39_aarch64.whl", hash = "sha256:ce1bd408ebaafc3dbdf39e860888382aae69de2b3c949dadfd132779130b99b2", size = 34579294, upload-time = "2026-05-02T13:12:12.069Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cf/d792cf46292f7756f96727916e77ebf9821371e22bff65ed8e90db6b80b9/falkordblite-0.10.0-cp313-cp313-manylinux_2_39_x86_64.whl", hash = "sha256:7d52a3665f6de30cbffc5809a1c6d722492c95bf8dae4a7ee108ca58da939b25", size = 36154069, upload-time = "2026-05-02T13:12:15.742Z" },
 ]
 
 [[package]]
@@ -1613,6 +1637,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/3a/950367aee7c69027f4f422059227b290ed780366b6aecee5de5039d50fa8/ruff-0.15.5-py3-none-win32.whl", hash = "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74", size = 10551676, upload-time = "2026-03-05T20:06:13.705Z" },
     { url = "https://files.pythonhosted.org/packages/b8/00/bf077a505b4e649bdd3c47ff8ec967735ce2544c8e4a43aba42ee9bf935d/ruff-0.15.5-py3-none-win_amd64.whl", hash = "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe", size = 11678972, upload-time = "2026-03-05T20:06:45.379Z" },
     { url = "https://files.pythonhosted.org/packages/fe/4e/cd76eca6db6115604b7626668e891c9dd03330384082e33662fb0f113614/ruff-0.15.5-py3-none-win_arm64.whl", hash = "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b", size = 10965572, upload-time = "2026-03-05T20:06:16.984Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Prerequisites (merge order)

Stacked on the full navigation confluence:
1. #690 → #691 → #698 (analyzer: base class, resolver, edges)
2. #678 → #679 → #680 → #681 (MCP tools: index_repo, query tools, impact_analysis, ask)
3. #701 — hybrid `search_code` + `get_neighbors` + `get_file_neighbors` (direct base)

Base: #701.

---

**Stacked draft on top of #701 (hybrid nav).** The headline navigation capability validated by the benchmark.

- **`find_symbol`** — name→symbol-id resolver. Bridges `search_code` (file-level fuzzy hits) to `get_neighbors`/`impact_analysis` (which need a symbol id). In the fair multi-hop nav re-run this enabled `find_symbol → get_neighbors` at a median of 2 nav calls, replacing a deep grep crawl: **tied accuracy at 0.69× baseline / 0.44× lsp tokens** on uxarray.
- **Drop `ask` from the MCP tool registration** — the GraphRAG `ask` tool requires `GEMINI_API_KEY`/`GOOGLE_API_KEY`, which the spawned MCP server env does not (and should not) carry. It errored 100% of the time under MCP. GraphRAG ask stays available over HTTP `/api/chat`. The `ask.py` module and its unit tests are untouched.

Final MCP surface: `find_path, get_file_neighbors, get_neighbors, impact_analysis, index_repo, search_code, find_symbol`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for embedded local database backend (FalkorDBLite) as an alternative to external server setup
  * Added symbol search tool to find functions and classes by name across your codebase

* **Documentation**
  * Updated setup instructions with new embedded database configuration option
  * Expanded environment variable documentation for database backend selection

* **Testing**
  * Added performance benchmarking suite for context optimization analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->