### PR TITLE
feat(analyzers): static name-based method-call CALLS edges with resolution tagging

### DIFF
--- a/api/analyzers/python/ts_resolver.py
+++ b/api/analyzers/python/ts_resolver.py
@@ -48,6 +48,14 @@ from api.entities.file import File
 logger = logging.getLogger(__name__)
 
 
+# Maximum number of same-named method definitions the guarded name-based
+# fallback will link a receiver-less ``obj.method()`` call to. Common method
+# names (``get`` / ``add`` / ``run`` / ``close`` ...) are defined on dozens of
+# classes; binding a call to all of them is a false-CALLS factory, so above this
+# count we emit no edge at all.
+_NAME_FALLBACK_MAX_CANDIDATES = 5
+
+
 # ---------------------------------------------------------------------------
 # Symbol table data model
 # ---------------------------------------------------------------------------
@@ -393,25 +401,154 @@ class TreeSitterPythonResolver:
         file_path: Path,
         project_root: Path,
         node: Node,
-    ) -> list[tuple[File, Node]]:
+    ) -> list[tuple[File, Node, str]]:
         """Resolve ``node`` (an identifier or dotted attribute) to definitions.
 
-        Returns a list of ``(File, def_node)`` tuples matching the shape
-        produced by ``AbstractAnalyzer.resolve``.
+        Returns a list of ``(File, def_node, resolution)`` tuples. ``resolution``
+        is ``"static_exact"`` for direct lookups (module top-level, imports,
+        dotted-attribute walks, unique bare names, and ``self``/``cls`` methods)
+        and ``"static_name"`` for the guarded receiver-agnostic method fallback.
         """
         self._ensure_built(files, project_root)
-        parts = _node_to_dotted_parts(node)
-        if not parts:
-            return []
         current_module = self._path_to_module.get(file_path)
-        candidate_defs = self._lookup(current_module, parts)
-        out: list[tuple[File, Node]] = []
-        for d in candidate_defs:
+
+        call_expr = _call_function_expr(node)
+        if call_expr is not None:
+            results = self._resolve_call(current_module, call_expr, node)
+        else:
+            # Non-call reference (type annotations, base classes, ...). Exact
+            # resolution only: no receiver reconstruction and no name-based
+            # method fallback, so type edges stay precisely as before.
+            parts = _node_to_dotted_parts(node)
+            results = (
+                [(d, "static_exact") for d in self._lookup(current_module, parts)]
+                if parts
+                else []
+            )
+
+        out: list[tuple[File, Node, str]] = []
+        for d, resolution in results:
             f = files.get(d.file_path)
             if f is None:
                 continue
-            out.append((f, d.node))
+            out.append((f, d.node, resolution))
         return out
+
+    def _resolve_call(
+        self,
+        current_module: Optional[str],
+        call_expr: Node,
+        site_node: Node,
+    ) -> list[tuple[_Definition, str]]:
+        """Resolve a call's function expression to ``(_Definition, resolution)``."""
+        parts = _node_to_dotted_parts(call_expr)
+        if not parts:
+            return []
+        head = parts[0]
+        method_name = parts[-1]
+
+        # 1. ``self.method()`` / ``cls.method()`` -> the *enclosing* class's own
+        # method (exact). Inherited methods aren't found locally and fall through
+        # to the guarded name fallback below.
+        if len(parts) >= 2 and head in ("self", "cls"):
+            method_def = self._resolve_self_method(
+                current_module, call_expr, site_node, head, method_name
+            )
+            if method_def is not None:
+                return [(method_def, "static_exact")]
+
+        # 2. Exact resolution: module top-level, imports, dotted walk, or a
+        # unique cross-module bare name.
+        exact = self._lookup(current_module, parts)
+        if exact:
+            return [(d, "static_exact") for d in exact]
+
+        # 3. Guarded name-based method fallback for ``receiver.method()`` whose
+        # receiver type can't be resolved statically (e.g. unannotated params).
+        # Restrict to a *simple identifier* receiver: chained calls, subscripts,
+        # and dotted receivers (``a.b.c()``, ``x.y().z()``) give no head we can
+        # trust, so we never guess a method binding for them.
+        if call_expr.type != "attribute":
+            return []
+        receiver = call_expr.child_by_field_name("object")
+        if receiver is None or receiver.type != "identifier" or head == "super":
+            return []
+        # Only when the receiver head is genuinely unknown -- not an import
+        # alias, project top-level symbol, or module prefix. ``self``/``cls``
+        # reach here only as inherited-method fallthrough and always qualify.
+        if head not in ("self", "cls") and self._head_is_resolvable(current_module, head):
+            return []
+        return [(d, "static_name") for d in self._name_fallback(method_name)]
+
+    def _resolve_self_method(
+        self,
+        current_module: Optional[str],
+        call_expr: Node,
+        site_node: Node,
+        receiver: str,
+        method_name: str,
+    ) -> Optional[_Definition]:
+        """Resolve ``self.method``/``cls.method`` against the enclosing class.
+
+        Guards against binding when ``self``/``cls`` isn't actually the method
+        receiver in scope -- e.g. a ``@staticmethod`` referencing ``self`` or a
+        nested function that redefines the first parameter.
+        """
+        if call_expr.type != "attribute":
+            return None
+        recv_node = call_expr.child_by_field_name("object")
+        if recv_node is None or recv_node.type != "identifier":
+            return None
+        if not current_module or current_module not in self._modules:
+            return None
+        class_node = _enclosing_class_node(site_node)
+        if class_node is None:
+            return None
+        # The function immediately enclosing the call site must take ``receiver``
+        # as its first parameter for the binding to be sound.
+        func = _enclosing_function_node(site_node, class_node)
+        if func is None or _first_parameter_name(func) != receiver:
+            return None
+        name_node = class_node.child_by_field_name("name")
+        if name_node is None:
+            return None
+        class_name = name_node.text.decode("utf-8")
+        mi = self._modules[current_module]
+        return mi.class_methods.get(class_name, {}).get(method_name)
+
+    def _head_is_resolvable(self, current_module: Optional[str], head: str) -> bool:
+        """Whether the receiver ``head`` names something we can place statically.
+
+        Distinguishes "head not found at all" (an unknown/local receiver such as
+        an unannotated parameter, which qualifies for the name fallback) from
+        "head is a known symbol whose tail walk merely failed" (does not).
+        """
+        if current_module and current_module in self._modules:
+            mi = self._modules[current_module]
+            if head in mi.imports or head in mi.top_level:
+                return True
+        if head in self._modules:
+            return True
+        # A project-wide top-level definition (class/func/var) by this name.
+        for d in self._by_name.get(head, ()):
+            if d.kind != "method":
+                return True
+        return False
+
+    def _name_fallback(self, method_name: str) -> list[_Definition]:
+        """Return method defs named ``method_name`` (guarded by a count cap)."""
+        candidates = [d for d in self._by_name.get(method_name, ()) if d.kind == "method"]
+        if not candidates:
+            return []
+        if len(candidates) > _NAME_FALLBACK_MAX_CANDIDATES:
+            logger.debug(
+                "ts_resolver: skipping name fallback for %r (%d candidates > %d)",
+                method_name, len(candidates), _NAME_FALLBACK_MAX_CANDIDATES,
+            )
+            return []
+        # Deterministic ordering so edge writes are stable across runs/workers.
+        candidates.sort(key=lambda d: (str(d.file_path), d.node.start_byte))
+        return candidates
 
     def _lookup(self, current_module: Optional[str], parts: list[str]) -> list[_Definition]:
         if not parts:
@@ -528,6 +665,81 @@ def _strip_decorator(def_node: Node) -> Node:
             if child.type in ("class_definition", "function_definition"):
                 return child
     return def_node
+
+
+def _enclosing_class_node(node: Node) -> Optional[Node]:
+    """Return the nearest enclosing ``class_definition`` ancestor of ``node``.
+
+    Used to bind ``self``/``cls`` to the class that owns the containing method.
+    Walking strictly upward keeps nested classes/functions correct: the call
+    site's first ``class_definition`` ancestor is the class whose ``self`` is in
+    scope.
+    """
+    cur = node.parent
+    while cur is not None:
+        if cur.type == "class_definition":
+            return cur
+        cur = cur.parent
+    return None
+
+
+def _call_function_expr(node: Node) -> Optional[Node]:
+    """If ``node`` sits in a call's *function* position, return that expression.
+
+    Handles both shapes reaching the resolver: the full call-function node
+    (``Foo.bar`` / ``helper``) and the bare method-name identifier (``bar``)
+    that ``PythonAnalyzer._extract_call_target`` produces for ``recv.method()``
+    in production. Returns ``None`` for non-call references (type annotations,
+    base classes, plain name reads) so they keep exact-only resolution.
+    """
+    parent = node.parent
+    if parent is None:
+        return None
+    if parent.type == "call" and parent.child_by_field_name("function") == node:
+        return node
+    if parent.type == "attribute" and parent.child_by_field_name("attribute") == node:
+        grand = parent.parent
+        if (
+            grand is not None
+            and grand.type == "call"
+            and grand.child_by_field_name("function") == parent
+        ):
+            return parent
+    return None
+
+
+def _enclosing_function_node(node: Node, stop_at: Node) -> Optional[Node]:
+    """Nearest ``function_definition`` ancestor of ``node`` below ``stop_at``.
+
+    ``stop_at`` is the owning class; the search never crosses it so a method's
+    own ``function_definition`` (not the class) is returned.
+    """
+    cur = node.parent
+    while cur is not None and cur != stop_at:
+        if cur.type == "function_definition":
+            return cur
+        cur = cur.parent
+    return None
+
+
+def _first_parameter_name(func_node: Node) -> Optional[str]:
+    """Return the textual name of a function's first positional parameter."""
+    params = func_node.child_by_field_name("parameters")
+    if params is None:
+        return None
+    for child in params.named_children:
+        if child.type == "identifier":
+            return child.text.decode("utf-8")
+        # ``self: Foo`` / ``self=...`` -- unwrap to the bound identifier.
+        if child.type in ("typed_parameter", "default_parameter", "typed_default_parameter"):
+            inner = child.child_by_field_name("name")
+            if inner is None:
+                inner = next(
+                    (c for c in child.named_children if c.type == "identifier"), None
+                )
+            return inner.text.decode("utf-8") if inner is not None else None
+        return None
+    return None
 
 
 def _node_to_dotted_parts(node: Node) -> list[str]:

--- a/api/analyzers/source_analyzer.py
+++ b/api/analyzers/source_analyzer.py
@@ -301,7 +301,11 @@ class SourceAnalyzer():
                 file = self.files[file_path]
                 for _, entity in file.entities.items():
                     for key, resolved_set in entity.resolved_symbols.items():
-                        for resolved in resolved_set:
+                        # Deterministic order so edge writes are stable across
+                        # worker counts (Phase B promises bit-identical output).
+                        for resolved, resolution in sorted(
+                            resolved_set.items(), key=lambda kv: kv[0].id
+                        ):
                             if key == "base_class":
                                 graph.connect_entities("EXTENDS", entity.id, resolved.id)
                             elif key == "implement_interface":
@@ -309,7 +313,10 @@ class SourceAnalyzer():
                             elif key == "extend_interface":
                                 graph.connect_entities("EXTENDS", entity.id, resolved.id)
                             elif key == "call":
-                                graph.connect_entities("CALLS", entity.id, resolved.id)
+                                graph.connect_entities(
+                                    "CALLS", entity.id, resolved.id,
+                                    {"resolution": resolution},
+                                )
                             elif key == "return_type":
                                 graph.connect_entities("RETURNS", entity.id, resolved.id)
                             elif key == "parameters":

--- a/api/analyzers/tree_sitter_base.py
+++ b/api/analyzers/tree_sitter_base.py
@@ -50,8 +50,13 @@ class TreeSitterAnalyzer(AbstractAnalyzer):
         path: Path,
         key: str,
         symbol: Node,
-    ) -> list[Entity]:
-        """Dispatch a captured symbol to type or callable resolution."""
+    ) -> list:
+        """Dispatch a captured symbol to type or callable resolution.
+
+        Returns bare ``Entity`` objects for type resolution and
+        ``(Entity, resolution)`` tuples for callable resolution; callers
+        normalize both shapes (see ``Entity.resolved_symbol``).
+        """
         if key in self.type_resolution_keys:
             return self.resolve_type(files, lsp, file_path, path, symbol)
         if key in self.method_resolution_keys:
@@ -79,7 +84,10 @@ class TreeSitterAnalyzer(AbstractAnalyzer):
         target = self._extract_type_target(node)
         if target is None:
             return res
-        for file, resolved_node in self.resolve(files, lsp, file_path, path, target):
+        # ``resolve`` may yield 2-tuples (LSP/jedi) or 3-tuples (static
+        # resolver, carrying a resolution kind). Type edges ignore the
+        # resolution kind, so unpack tolerantly.
+        for file, resolved_node, *_ in self.resolve(files, lsp, file_path, path, target):
             type_dec = self.find_parent(resolved_node, self.type_definition_node_types)
             if type_dec in file.entities:
                 res.append(file.entities[type_dec])
@@ -92,16 +100,23 @@ class TreeSitterAnalyzer(AbstractAnalyzer):
         file_path: Path,
         path: Path,
         node: Node,
-    ) -> list[Entity]:
-        """Resolve a call reference to matching callable-definition entities."""
+    ) -> list[tuple[Entity, str]]:
+        """Resolve a call reference to matching callable-definition entities.
+
+        Returns ``(entity, resolution)`` pairs. ``resolution`` is the kind
+        reported by the resolver (``static_exact`` / ``static_name`` for the
+        static tree-sitter resolver) and defaults to ``"lsp"`` for resolvers
+        that yield bare ``(file, node)`` pairs.
+        """
         res = []
         target = self._extract_call_target(node)
         if target is None:
             return res
-        for file, resolved_node in self.resolve(files, lsp, file_path, path, target):
+        for file, resolved_node, *rest in self.resolve(files, lsp, file_path, path, target):
+            resolution = rest[0] if rest else "lsp"
             method_dec = self.find_parent(resolved_node, self.callable_definition_node_types)
             if method_dec and method_dec.type in self.callable_exclude_node_types:
                 continue
             if method_dec in file.entities:
-                res.append(file.entities[method_dec])
+                res.append((file.entities[method_dec], resolution))
         return res

--- a/api/entities/entity.py
+++ b/api/entities/entity.py
@@ -2,11 +2,22 @@ from typing import Callable, Self
 from tree_sitter import Node
 
 
+# Resolution confidence ranking. A callee reached by several symbols (or by both
+# the exact and the name-based fallback path) keeps its highest-confidence tag:
+# an exact static resolution must never be downgraded to a name-based guess.
+_RESOLUTION_RANK = {"static_name": 0, "lsp": 1, "static_exact": 2}
+
+
+def _resolution_rank(resolution: str) -> int:
+    return _RESOLUTION_RANK.get(resolution, _RESOLUTION_RANK["lsp"])
+
+
 class Entity:
     def __init__(self, node: Node):
         self.node = node
         self.symbols: dict[str, list[Node]] = {}
-        self.resolved_symbols: dict[str, set[Self]] = {}
+        # callee entity -> resolution kind ('static_exact' | 'lsp' | 'static_name')
+        self.resolved_symbols: dict[str, dict[Self, str]] = {}
         self.children: dict[Node, Self] = {}
 
     def add_symbol(self, key: str, symbol: Node):
@@ -14,18 +25,31 @@ class Entity:
             self.symbols[key] = []
         self.symbols[key].append(symbol)
 
-    def add_resolved_symbol(self, key: str, symbol: Self):
-        if key not in self.resolved_symbols:
-            self.resolved_symbols[key] = set()
-        self.resolved_symbols[key].add(symbol)
+    def add_resolved_symbol(self, key: str, symbol: Self, resolution: str = "lsp"):
+        bucket = self.resolved_symbols.setdefault(key, {})
+        self._record(bucket, symbol, resolution)
 
     def add_child(self, child: Self):
         child.parent = self
         self.children[child.node] = child
 
-    def resolved_symbol(self, f: Callable[[str, Node], list[Self]]):
+    @staticmethod
+    def _record(bucket: dict, symbol: Self, resolution: str) -> None:
+        existing = bucket.get(symbol)
+        if existing is None or _resolution_rank(resolution) > _resolution_rank(existing):
+            bucket[symbol] = resolution
+
+    def resolved_symbol(self, f: Callable[[str, Node], list]):
         for key, symbols in self.symbols.items():
-            self.resolved_symbols[key] = set()
+            bucket: dict[Self, str] = {}
+            self.resolved_symbols[key] = bucket
             for symbol in symbols:
-                for resolved_symbol in f(key, symbol):
-                    self.resolved_symbols[key].add(resolved_symbol)
+                for item in f(key, symbol):
+                    # Resolvers may return either a bare entity (legacy LSP/jedi
+                    # path) or an ``(entity, resolution)`` tuple (static
+                    # tree-sitter resolver). Normalize both shapes centrally.
+                    if isinstance(item, tuple):
+                        resolved, resolution = item
+                    else:
+                        resolved, resolution = item, "lsp"
+                    self._record(bucket, resolved, resolution)

--- a/tests/analyzers/test_ts_python_resolver.py
+++ b/tests/analyzers/test_ts_python_resolver.py
@@ -15,6 +15,7 @@ from api.analyzers.python.ts_resolver import (
     _node_to_dotted_parts,
     _path_to_module,
 )
+from api.entities.entity import Entity
 from api.entities.file import File
 
 
@@ -46,6 +47,19 @@ def _find_name_node(tree_root, text: str):
             return node
         stack.extend(node.children)
     raise AssertionError(f"identifier '{text}' not found")
+
+
+def _call_target(call_node):
+    """Mirror ``PythonAnalyzer._extract_call_target``.
+
+    Production passes the resolver the call's *method-name* identifier (the
+    ``attribute`` child) for ``recv.method()``, not the full dotted node. Tests
+    that exercise method-call resolution should feed the same shape.
+    """
+    func = call_node.child_by_field_name("function")
+    if func is not None and func.type == "attribute":
+        return func.child_by_field_name("attribute")
+    return func
 
 
 # ---------------------------------------------------------------------------
@@ -137,11 +151,12 @@ def test_resolver_local_module_function(tmp_path: Path):
     func_ident = helper_call.child_by_field_name("function")
     out = r.resolve(files, mod_path, tmp_path.resolve(), func_ident)
     assert len(out) == 1
-    file, def_node = out[0]
+    file, def_node, resolution = out[0]
     assert file.path == mod_path
     assert def_node.type == "function_definition"
     name = def_node.child_by_field_name("name").text.decode("utf-8")
     assert name == "helper"
+    assert resolution == "static_exact"
 
 
 def test_resolver_from_import_resolution(tmp_path: Path):
@@ -251,7 +266,7 @@ def test_resolver_many_defs_name_def_alignment(tmp_path: Path):
             files, app_path, tmp_path.resolve(), call.child_by_field_name("function")
         )
         assert len(out) == 1, f"fn_{i} did not resolve uniquely"
-        file, def_node = out[0]
+        file, def_node, _ = out[0]
         assert file.path == lib_path
         resolved_name = def_node.child_by_field_name("name").text.decode("utf-8")
         assert resolved_name == f"fn_{i}", (
@@ -447,3 +462,258 @@ def test_python_analyzer_default_still_uses_jedi():
         a = PythonAnalyzer()
         assert a._ts_resolver is None
         assert a.needs_lsp() is True
+
+
+# ---------------------------------------------------------------------------
+# Static method-call resolution: self/cls exact + guarded name fallback
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_name_fallback_single_method(tmp_path: Path):
+    """``g._query()`` with a single project method ``_query`` emits a CALLS edge
+    tagged ``static_name`` even though ``g``'s type is unknown."""
+    files = _make_project(
+        tmp_path,
+        {
+            "graph.py": "class Graph:\n    def _query(self, q):\n        return q\n",
+            "structural.py": "def _build_corpus(g):\n    g._query('x')\n",
+        },
+    )
+    r = TreeSitterPythonResolver(_PY)
+    sp = (tmp_path / "structural.py").resolve()
+    call = _find_call_node(files[sp].tree.root_node, "g._query(")
+    out = r.resolve(files, sp, tmp_path.resolve(), _call_target(call))
+    assert len(out) == 1
+    file, def_node, resolution = out[0]
+    assert file.path == (tmp_path / "graph.py").resolve()
+    assert def_node.child_by_field_name("name").text.decode("utf-8") == "_query"
+    assert resolution == "static_name"
+
+
+def test_resolver_self_method_exact_enclosing_class(tmp_path: Path):
+    """``self._query()`` resolves to the *enclosing* class's method (exact),
+    never to a same-named method on a different class."""
+    src = (
+        "class A:\n"
+        "    def _query(self, q):\n"
+        "        return q\n"
+        "    def run(self):\n"
+        "        self._query('x')\n\n"
+        "class B:\n"
+        "    def _query(self, q):\n"
+        "        return q * 2\n"
+    )
+    files = _make_project(tmp_path, {"mod.py": src})
+    r = TreeSitterPythonResolver(_PY)
+    mod = (tmp_path / "mod.py").resolve()
+    call = _find_call_node(files[mod].tree.root_node, "self._query(")
+    out = r.resolve(files, mod, tmp_path.resolve(), _call_target(call))
+    assert len(out) == 1
+    _, def_node, resolution = out[0]
+    assert resolution == "static_exact"
+    cls = def_node.parent
+    while cls is not None and cls.type != "class_definition":
+        cls = cls.parent
+    assert cls is not None
+    assert cls.child_by_field_name("name").text.decode("utf-8") == "A"
+
+
+def test_resolver_import_prefix_blocks_name_fallback(tmp_path: Path):
+    """``logging.getLogger()`` with ``logging`` imported must NOT bind to a
+    project method named ``getLogger`` -- the import-prefix guard rejects it."""
+    files = _make_project(
+        tmp_path,
+        {
+            "util.py": "class Log:\n    def getLogger(self):\n        return 1\n",
+            "app.py": "import logging\n\ndef f():\n    logging.getLogger()\n",
+        },
+    )
+    r = TreeSitterPythonResolver(_PY)
+    app = (tmp_path / "app.py").resolve()
+    call = _find_call_node(files[app].tree.root_node, "logging.getLogger(")
+    out = r.resolve(files, app, tmp_path.resolve(), _call_target(call))
+    assert out == []
+
+
+def test_resolver_external_module_method_no_edge(tmp_path: Path):
+    """``requests.get()`` (external import) must not bind to project ``get``
+    methods even when the candidate count is under threshold."""
+    files = _make_project(
+        tmp_path,
+        {
+            "models.py": "class Session:\n    def get(self):\n        return 1\n",
+            "app.py": "import requests\n\ndef f():\n    requests.get()\n",
+        },
+    )
+    r = TreeSitterPythonResolver(_PY)
+    app = (tmp_path / "app.py").resolve()
+    call = _find_call_node(files[app].tree.root_node, "requests.get(")
+    out = r.resolve(files, app, tmp_path.resolve(), _call_target(call))
+    assert out == []
+
+
+def test_resolver_name_fallback_threshold_skips(tmp_path: Path):
+    """More same-named method defs than the threshold => no edge (avoids the
+    common-method-name explosion)."""
+    lib = "".join(
+        f"class C{i}:\n    def get(self):\n        return {i}\n\n" for i in range(6)
+    )
+    files = _make_project(
+        tmp_path,
+        {"lib.py": lib, "app.py": "def f(g):\n    g.get()\n"},
+    )
+    r = TreeSitterPythonResolver(_PY)
+    app = (tmp_path / "app.py").resolve()
+    call = _find_call_node(files[app].tree.root_node, "g.get(")
+    out = r.resolve(files, app, tmp_path.resolve(), _call_target(call))
+    assert out == []
+
+
+def test_resolver_name_fallback_at_threshold_returns_all(tmp_path: Path):
+    """Exactly threshold-many candidates are all returned, tagged static_name
+    and deterministically ordered by (file_path, start_byte)."""
+    lib = "".join(
+        f"class C{i}:\n    def fetch(self):\n        return {i}\n\n" for i in range(5)
+    )
+    files = _make_project(
+        tmp_path,
+        {"lib.py": lib, "app.py": "def f(g):\n    g.fetch()\n"},
+    )
+    r = TreeSitterPythonResolver(_PY)
+    app = (tmp_path / "app.py").resolve()
+    call = _find_call_node(files[app].tree.root_node, "g.fetch(")
+    out = r.resolve(files, app, tmp_path.resolve(), _call_target(call))
+    assert len(out) == 5
+    assert all(resolution == "static_name" for _, _, resolution in out)
+    starts = [def_node.start_byte for _, def_node, _ in out]
+    assert starts == sorted(starts)
+
+
+def test_resolver_super_call_no_name_fallback(tmp_path: Path):
+    """``super().foo()`` must not trigger the global name fallback."""
+    files = _make_project(
+        tmp_path,
+        {
+            "base.py": "class Base:\n    def foo(self):\n        return 1\n",
+            "child.py": (
+                "class Child:\n"
+                "    def foo(self):\n"
+                "        super().foo()\n"
+            ),
+        },
+    )
+    r = TreeSitterPythonResolver(_PY)
+    child = (tmp_path / "child.py").resolve()
+    call = _find_call_node(files[child].tree.root_node, "super().foo(")
+    out = r.resolve(files, child, tmp_path.resolve(), _call_target(call))
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Entity resolution-precedence + normalization
+# ---------------------------------------------------------------------------
+
+
+def test_entity_resolution_precedence_static_exact_wins():
+    tree = _PARSER.parse(b"x = 1\n")
+    node = tree.root_node
+    caller = Entity(node)
+    callee = Entity(node)
+    caller.add_resolved_symbol("call", callee, "static_name")
+    caller.add_resolved_symbol("call", callee, "static_exact")
+    assert caller.resolved_symbols["call"][callee] == "static_exact"
+    # lsp (and a later static_name) must never downgrade static_exact.
+    caller.add_resolved_symbol("call", callee, "lsp")
+    caller.add_resolved_symbol("call", callee, "static_name")
+    assert caller.resolved_symbols["call"][callee] == "static_exact"
+
+
+def test_entity_resolved_symbol_normalizes_tuples_and_bare():
+    tree = _PARSER.parse(b"x = 1\n")
+    node = tree.root_node
+    e = Entity(node)
+    e.add_symbol("call", node)
+    callee_a = Entity(node)
+    callee_b = Entity(node)
+
+    def f(key, symbol):
+        # tuple (static resolver) + bare entity (legacy LSP/jedi)
+        return [(callee_a, "static_name"), callee_b]
+
+    e.resolved_symbol(f)
+    assert e.resolved_symbols["call"][callee_a] == "static_name"
+    assert e.resolved_symbols["call"][callee_b] == "lsp"
+
+
+def test_resolver_chained_receiver_no_name_fallback(tmp_path: Path):
+    """A chained receiver (``line.strip().split()``) has no head we can trust,
+    so the name fallback must not fire even with a project method ``split``."""
+    files = _make_project(
+        tmp_path,
+        {
+            "lib.py": "class Tok:\n    def split(self):\n        return 1\n",
+            "app.py": "def f(line):\n    line.strip().split()\n",
+        },
+    )
+    r = TreeSitterPythonResolver(_PY)
+    app = (tmp_path / "app.py").resolve()
+    call = _find_call_node(files[app].tree.root_node, "line.strip().split(")
+    out = r.resolve(files, app, tmp_path.resolve(), _call_target(call))
+    assert out == []
+
+
+def test_resolver_dotted_receiver_no_name_fallback(tmp_path: Path):
+    """A dotted receiver (``a.b.method()``) is rejected by the simple-identifier
+    guard -- only ``identifier.method()`` is eligible for the name fallback."""
+    files = _make_project(
+        tmp_path,
+        {
+            "lib.py": "class C:\n    def ping(self):\n        return 1\n",
+            "app.py": "def f(a):\n    a.b.ping()\n",
+        },
+    )
+    r = TreeSitterPythonResolver(_PY)
+    app = (tmp_path / "app.py").resolve()
+    call = _find_call_node(files[app].tree.root_node, "a.b.ping(")
+    out = r.resolve(files, app, tmp_path.resolve(), _call_target(call))
+    assert out == []
+
+
+def test_resolver_self_in_staticmethod_not_exact(tmp_path: Path):
+    """``self.method()`` inside a ``@staticmethod`` (no ``self`` parameter) must
+    not produce a high-confidence ``static_exact`` edge to the enclosing class."""
+    src = (
+        "class A:\n"
+        "    def _query(self, q):\n"
+        "        return q\n"
+        "    @staticmethod\n"
+        "    def f():\n"
+        "        self._query('x')\n"
+    )
+    files = _make_project(tmp_path, {"mod.py": src})
+    r = TreeSitterPythonResolver(_PY)
+    mod = (tmp_path / "mod.py").resolve()
+    call = _find_call_node(files[mod].tree.root_node, "self._query(")
+    out = r.resolve(files, mod, tmp_path.resolve(), _call_target(call))
+    # No static_exact binding; at most a low-confidence name-based guess.
+    assert all(resolution != "static_exact" for _, _, resolution in out)
+
+
+def test_resolver_self_in_nested_function_shadowing_not_exact(tmp_path: Path):
+    """A nested function that redefines the first parameter shadows the method's
+    ``self``; the enclosing-function first-parameter guard must reject it."""
+    src = (
+        "class A:\n"
+        "    def _query(self, q):\n"
+        "        return q\n"
+        "    def outer(self):\n"
+        "        def inner(other):\n"
+        "            self._query('x')\n"
+        "        return inner\n"
+    )
+    files = _make_project(tmp_path, {"mod.py": src})
+    r = TreeSitterPythonResolver(_PY)
+    mod = (tmp_path / "mod.py").resolve()
+    call = _find_call_node(files[mod].tree.root_node, "self._query(")
+    out = r.resolve(files, mod, tmp_path.resolve(), _call_target(call))
+    assert all(resolution != "static_exact" for _, _, resolution in out)


### PR DESCRIPTION
## Problem

The static tree-sitter Python resolver (`CODE_GRAPH_PY_RESOLVER=tree_sitter`) returned **zero** `CALLS` edges for method calls whose receiver type isn't statically resolvable — `g._query(...)` where `g` is an unannotated parameter, and even `self._query(...)`. Both reduce to a bare method name that the existing bare-name fallback excludes (methods need a receiver), so the edge was dropped. ~90% of method calls in this codebase use a non-`self` receiver, so recall was badly hurt. The jedi/LSP path misses these too (can't infer the param type through dynamic dispatch).

Concrete missing example: `api/mcp/tools/structural.py::_build_corpus` calls `g._query(...)` but had no `CALLS` edge to `api/graph.py::_query`.

## What changed

**`self.method()` / `cls.method()` → `static_exact`**
Walks up to the enclosing `class_definition` that owns the containing method and resolves the method there. Guarded by an enclosing-function first-parameter check so a `@staticmethod` referencing `self`, or a nested function that shadows the receiver, doesn't produce a wrong high-confidence edge. Inherited (not-found-locally) methods fall through to the name fallback.

**Guarded name-based fallback for other receivers (`g._query`, `obj.method`) → `static_name`**
Only fires when *all* hold:
- exact resolution returned nothing, and
- the receiver is a **simple identifier** (`g._query()`) — chained calls / subscripts / dotted receivers (`a.b.c()`, `x.y().z()`) are rejected, and
- the receiver head is **genuinely unknown** — not a current-module import alias, project top-level symbol, module prefix, or global non-method def (this is the import-prefix guard that blocks `logging.getLogger()` / `requests.get()` from binding to project methods), and
- the receiver is not `super`.

Then it binds to project method defs of the same name, subject to a **candidate-count threshold** (module constant, 5): if more than the threshold same-named method defs exist, no edge is emitted (avoids `get`/`add`/`run`/`close` explosions). Candidates are sorted deterministically.

**`resolution` tagging threaded end-to-end**
- `TreeSitterPythonResolver.resolve()` → `list[(File, Node, resolution)]`.
- `tree_sitter_base.resolve_method()` → `list[(Entity, resolution)]`; `resolve_type()` stays bare entities. The jedi/Java/C#/Kotlin paths default to `"lsp"` — **no behavior change**.
- `Entity.resolved_symbols`: `dict[str, dict[Entity, str]]` with precedence **`static_exact` > `lsp` > `static_name`** (never downgrade a better value), normalizing both bare-entity and `(entity, resolution)` shapes centrally.
- `source_analyzer.py` Phase B writes `{"resolution": ...}` on **CALLS edges only**; EXTENDS/IMPLEMENTS/RETURNS/PARAMETERS are unchanged. Phase B determinism preserved (writes sorted by entity id).

## Before / after

Indexed this repo's `api/` with the static resolver (lite backend):

| metric | before | after |
|---|---|---|
| Function→Function `CALLS` | 269 | **498** |
| total `CALLS` | 313 | 542 |
| `_build_corpus → _query` | ❌ absent | ✅ present (`static_name`) |
| `self._query` callers in `graph.py` | — | `static_exact` (30) |

Resolution breakdown after: `static_exact`=363, `static_name`=179. The exact count also rose (269→363) because receiver reconstruction recovered `self.method()` / `Foo.bar()` / dotted walks the previous `_extract_call_target` stripping dropped.

**No false-edge explosion:** top `static_name` fan-in is `close`=30 (a real project method), `resolve`=24, `_query`=14 — all plausible; `get`=0.

## Known limitation

The resolver indexes all `.py` files (including a checked-in `venv`/vendored libs) into its name-fallback table — pre-existing behavior, not a regression. With a vendored tree present, common method names (`append`/`items`/`split`) could collide; the `static_name` tag lets consumers filter such low-confidence edges. A first-party-only fallback index is a possible follow-up.

## Tests

`tests/analyzers/test_ts_python_resolver.py` updated for the 3-tuple return and extended with: single-method name fallback, self/cls exact (enclosing-class only), import-prefix guard, external-module guard, threshold skip + at-threshold pass, `super()` skip, chained/dotted receiver rejection, staticmethod / nested-shadowing self guards, and entity precedence/normalization. `make lint-py` clean (no new ruff errors); resolver + base + determinism tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Python symbol resolution to more accurately track method calls and their dependencies.
  * Improved call-edge tracking with confidence indicators for resolution quality.

* **Tests**
  * Added comprehensive test coverage for method call resolution, symbol precedence, and edge-case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->