### PR TITLE
fix(graph): correct delete_files return contract

### DIFF
--- a/api/graph.py
+++ b/api/graph.py
@@ -520,13 +520,16 @@ class Graph():
         node    = res.result_set[0][0]
         file.id = node.id
 
-    def delete_files(self, files: list[Path]) -> tuple[str, dict, list[int]]:
+    def delete_files(self, files: list[Path]) -> None:
         """
         Deletes file(s) from the graph in addition to any other entity
         defined in the file
 
         a file is defined by its path, name and extension
         files = [{'path':_, 'name': _, 'ext': _}, ...]
+
+        Returns:
+            None
         """
 
         q = """UNWIND $files AS file
@@ -538,7 +541,6 @@ class Graph():
         params = {'files': [{'path': str(file_path), 'name': file_path.name, 'ext' : file_path.suffix} for file_path in files]}
         self._query(q, params)
 
-        return None
 
     def get_file(self, path: str, name: str, ext: str) -> Optional[Node]:
         """

--- a/tests/test_graph_delete_files.py
+++ b/tests/test_graph_delete_files.py
@@ -1,0 +1,16 @@
+from inspect import signature
+from pathlib import Path
+from unittest.mock import Mock
+
+from api.graph import Graph
+
+
+def test_delete_files_return_contract() -> None:
+    graph = Graph.__new__(Graph)
+    graph._query = Mock()
+
+    result = graph.delete_files([Path("src/example.py")])
+
+    assert result is None
+    assert signature(Graph.delete_files).return_annotation is None
+    graph._query.assert_called_once()


### PR DESCRIPTION
Fixes #569

## Root cause
`Graph.delete_files()` always returned `None`, and both production callers use it only for its graph-deletion side effect. Its annotation incorrectly advertised a tuple return value, misleading type checkers and callers.

## Changes
- Change the return annotation from `tuple[str, dict, list[int]]` to `None`.
- Document the side-effect-only return contract.
- Add an isolated unit test that verifies the runtime return, annotation, and graph query invocation without requiring FalkorDB.

## Impact
Only the Python type contract and documentation change. The Cypher query, parameters, deletion behavior, and existing callers are unchanged.

## Verification
- `uv run pytest tests/test_graph_delete_files.py -q` — passed (1 test).
- `uv run ruff check api/graph.py tests/test_graph_delete_files.py` — passed.
- `git diff --check` — passed.
- Sensitive-data regex scan of the diff — no matches.

## Checks not run
- The broader `uv run pytest tests/test_git_history.py tests/test_graph_delete_files.py -q` could not complete because the checkout does not contain the required `tests/git_repo` fixture; the new isolated test passed in that invocation.
- Full integration tests requiring FalkorDB were not run.

## Risk and rollback
Low risk: runtime behavior is unchanged. A caller that incorrectly relied on the old tuple annotation will now receive the accurate type-checking result. Roll back by reverting the single commit; no data or configuration migration is involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency for file deletion operations by clarifying that the action completes without returning result data.
  - File and related entity removal behavior remains unchanged.

- **Tests**
  - Added coverage to verify the deletion operation’s return behavior and ensure the graph query executes as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->