### PR TITLE
docs(ci): correct stale action version comments after major bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           cache: "npm"
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Build Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7

--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,9 +25,9 @@ jobs:
         ports:
           - 6379:6379
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: 24
         cache: 'npm'
@@ -66,7 +66,7 @@ jobs:
 
     - name: Cache Playwright browsers
       id: playwright-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set tags
         run: |


### PR DESCRIPTION
## Summary
Dependabot's recent major bumps updated the pinned SHAs but left the trailing version comments pointing at the previous major, so the workflows *read* as if they were still on the old versions.

Verified against the upstream tag refs:

| Action | Pinned SHA resolves to | Comment said |
|---|---|---|
| `actions/checkout` | **v7.0.1** | `# v6` |
| `actions/setup-node` | **v7.0.0** | `# v6` |
| `actions/cache` | **v6.1.0** | `# v5` |

CI has already been running the v7/v6 actions — this only corrects the misleading comments.

## Changes
- Update the version comments on the `actions/checkout`, `actions/setup-node` and `actions/cache` pins across all five workflow files.

## Testing
Comment-only change; **no SHA is modified** (`git diff` touches only text after `#`). Existing CI on this PR exercises the same pinned actions.

`pypa/gh-action-pypi-publish` is intentionally left as `# release/v1` — that's the upstream project's own documented moving ref, not a stale major.

## Memory / Performance Impact
N/A.

## Related Issues
Follow-up to #718, #719, #720.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and release workflows to use the latest documented versions of checkout, Node setup, and caching actions.
  * Retained pinned revisions to preserve consistent and reproducible workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->