### PR TITLE
fix(deps): pin graphrag-sdk to <0.9.0 and build image from uv.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,12 @@ WORKDIR /app
 # Install Python dependencies pinned to uv.lock so the image matches CI.
 # uv is pinned too: it produces the constraints file, so an unpinned
 # upgrade could change `uv export` semantics and break reproducibility.
+# It is removed in the same layer, since only the export step needs it.
 ARG UV_VERSION=0.12.5
 COPY pyproject.toml uv.lock ./
 RUN pip install --no-cache-dir --break-system-packages "uv==${UV_VERSION}" \
     && uv export --frozen --no-dev --no-emit-project --no-hashes -o /tmp/constraints.txt \
+    && pip uninstall -y --break-system-packages uv \
     && pip install --no-cache-dir --break-system-packages -c /tmp/constraints.txt . \
     && rm /tmp/constraints.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,12 @@ RUN apt-get update \
 
 WORKDIR /app
 
-# Install Python dependencies
-COPY pyproject.toml ./
-RUN pip install --no-cache-dir --break-system-packages .
+# Install Python dependencies pinned to uv.lock so the image matches CI
+COPY pyproject.toml uv.lock ./
+RUN pip install --no-cache-dir --break-system-packages uv \
+    && uv export --frozen --no-dev --no-emit-project --no-hashes -o /tmp/constraints.txt \
+    && pip install --no-cache-dir --break-system-packages -c /tmp/constraints.txt . \
+    && rm /tmp/constraints.txt
 
 # Verify Node.js tooling for building the frontend
 RUN node --version && npm --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,12 @@ RUN apt-get update \
 
 WORKDIR /app
 
-# Install Python dependencies pinned to uv.lock so the image matches CI
+# Install Python dependencies pinned to uv.lock so the image matches CI.
+# uv is pinned too: it produces the constraints file, so an unpinned
+# upgrade could change `uv export` semantics and break reproducibility.
+ARG UV_VERSION=0.12.5
 COPY pyproject.toml uv.lock ./
-RUN pip install --no-cache-dir --break-system-packages uv \
+RUN pip install --no-cache-dir --break-system-packages "uv==${UV_VERSION}" \
     && uv export --frozen --no-dev --no-emit-project --no-hashes -o /tmp/constraints.txt \
     && pip install --no-cache-dir --break-system-packages -c /tmp/constraints.txt . \
     && rm /tmp/constraints.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{name = "Roi Lipman", email = "roilipman@gmail.com"}]
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
-    "graphrag-sdk>=0.8.1,<1.2.0",
+    "graphrag-sdk>=0.8.1,<0.9.0",
     "tree-sitter>=0.25.2,<0.27.0",
     "validators>=0.35.0,<0.36.0",
     "falkordb>=1.1.3,<2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ requires-dist = [
     { name = "falkordb-multilspy", specifier = ">=0.1.0,<1.0.0" },
     { name = "falkordblite", marker = "extra == 'light'", specifier = ">=0.10.0,<1.0.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
-    { name = "graphrag-sdk", specifier = ">=0.8.1,<1.2.0" },
+    { name = "graphrag-sdk", specifier = ">=0.8.1,<0.9.0" },
     { name = "httpx", marker = "extra == 'test'", specifier = ">=0.28.0,<1.0.0" },
     { name = "javatools", specifier = ">=1.6.0,<2.0.0" },
     { name = "mcp", specifier = ">=1.0.0,<2.0.0" },


### PR DESCRIPTION
## Summary

Railway deployments of `staging` crash-loop on startup with:

```
File "/app/api/llm.py", line 7, in <module>
    from graphrag_sdk.models.litellm import LiteModel
ModuleNotFoundError: No module named 'graphrag_sdk.models'
```

Two independent problems combined to cause this:

1. **The version constraint was too wide.** #673 widened `graphrag-sdk` from `<0.9.0` to `<1.2.0`. graphrag-sdk 1.x is a complete rewrite — it dropped the `graphrag_sdk.models` subpackage and the entire `Ontology` / `Entity` / `Relation` / `KnowledgeGraph` / `KnowledgeGraphModelConfig` surface that `api/llm.py` imports. Verified against the published wheels:

   | version | top-level modules |
   |---|---|
   | 0.8.2 | `models`, `Ontology`, `KnowledgeGraph`, … |
   | 1.1.1 | `api`, `core`, `ingestion`, `retrieval`, `storage`, `telemetry`, `utils` — no `models` |

   A clean `pip install "graphrag-sdk>=0.8.1,<1.2.0"` resolves to **1.1.1**, so `import api` fails before uvicorn can start.

2. **The image ignored the lockfile.** `uv.lock` still pinned 0.8.2, so `uv sync` in CI kept working and every workflow stayed green. The Dockerfile, however, ran `pip install .` directly against `pyproject.toml`, which re-resolved to the newest allowed version. That is why this only ever reproduced in the deployed container and never in CI.

## Changes

- `pyproject.toml`: restore the `graphrag-sdk>=0.8.1,<0.9.0` upper bound.
- `uv.lock`: refresh the recorded specifier (resolution is unchanged — still 0.8.2).
- `Dockerfile`: export constraints from `uv.lock` with `uv export --frozen` and install under `-c`, so image dependencies can no longer drift from the lockfile. This closes the CI-green / deploy-broken gap for *all* dependencies, not just this one.

## Testing

- Reproduced the root cause: `pip install "graphrag-sdk>=0.8.1,<1.2.0"` resolves to `1.1.1`; confirmed the 1.1.1 wheel contains no `graphrag_sdk/models`.
- Built the amended Dockerfile dependency stage end-to-end — installs `graphrag-sdk 0.8.2`, and `from graphrag_sdk.models.litellm import LiteModel` plus the `Ontology`/`KnowledgeGraph` imports all succeed inside the image.
- `import api` (what uvicorn does at startup) succeeds locally.
- Backend test subset: **141 passed / 7 failed**, byte-identical to the same subset on an unmodified checkout — the 7 failures are pre-existing and environmental.
- `uv lock --check` passes; `ruff` error count unchanged (40 before and after).

## Memory / Performance Impact

N/A — dependency pinning and build configuration only. No runtime code changed.

## Related Issues

Regression introduced by #673.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved production container build consistency by pinning the package installer version.
  * Production builds now use a frozen, compatible dependency set and exclude development-only tooling.

* **Bug Fixes**
  * Restricted supported `graphrag-sdk` versions to the compatible 0.8.x range, helping prevent incompatible installations and improving deployment reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->