### PR TITLE
fix(docker): install the project after its sources are copied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,16 +37,16 @@ RUN apt-get update \
 WORKDIR /app
 
 # Install Python dependencies pinned to uv.lock so the image matches CI.
-# uv is pinned too: it produces the constraints file, so an unpinned
+# uv is pinned too: it produces the requirements file, so an unpinned
 # upgrade could change `uv export` semantics and break reproducibility.
 # It is removed in the same layer, since only the export step needs it.
 ARG UV_VERSION=0.12.5
 COPY pyproject.toml uv.lock ./
 RUN pip install --no-cache-dir --break-system-packages "uv==${UV_VERSION}" \
-    && uv export --frozen --no-dev --no-emit-project --no-hashes -o /tmp/constraints.txt \
+    && uv export --frozen --no-dev --no-emit-project --no-hashes -o /tmp/requirements.txt \
     && pip uninstall -y --break-system-packages uv \
-    && pip install --no-cache-dir --break-system-packages -c /tmp/constraints.txt . \
-    && rm /tmp/constraints.txt
+    && pip install --no-cache-dir --break-system-packages -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
 
 # Verify Node.js tooling for building the frontend
 RUN node --version && npm --version
@@ -65,6 +65,13 @@ RUN npm --prefix ./app run build
 
 # Copy backend code
 COPY ./api ./api
+
+# Install the project itself now that its sources (and the README the
+# metadata references) are present, so the `api` package, its template
+# package-data and the cgraph/cgraph-mcp entry points all land in
+# site-packages. Dependencies are already installed and pinned above.
+COPY README.md ./
+RUN pip install --no-cache-dir --break-system-packages --no-deps .
 
 # Copy and make start.sh executable
 COPY start.sh /start.sh


### PR DESCRIPTION
## Summary

Follow-up to #723, which merged before this last review point could be addressed.

`pip install .` runs immediately after `COPY pyproject.toml uv.lock ./`, i.e. with **no project sources present**. `[tool.setuptools.packages.find]` therefore matches nothing, so the `api` package, the `api.mcp` templates package-data and the console scripts never reach `site-packages`.

Because a console script resolves imports from its own `bin` directory rather than the working directory, both entry points are dead in the shipped image:

```
api installed: False
cgraph BROKEN
cgraph-mcp BROKEN
```

That makes the documented `CGRAPH_MODE=mcp` path in `start.sh` (`exec cgraph-mcp`) unable to start at all. Web mode only works by accident, because uvicorn adds the working directory to the import path.

## Changes

- Dependency layer now installs the exported `uv.lock` set directly (`-r requirements.txt`) instead of using it as constraints for a source install, keeping that layer cache-friendly and free of project sources.
- The project itself is installed with `--no-deps` **after** `COPY ./api ./api`, so the package, its package-data and both entry points land in `site-packages`.
- `README.md` is copied alongside it, since `pyproject.toml` declares `readme = "README.md"` for its metadata.

## Testing

Full build of the real Dockerfile, then inspected the resulting image:

```
OK: uv gone
graphrag-sdk Version: 0.8.2
api installed: True
cgraph OK            <- run from / , not /app
cgraph-mcp OK        <- run from / , not /app
templates dir: .../site-packages/api/mcp/templates exists: True
                 ['claude_mcp_section.md', 'cursorrules.template']
STATIC_DIR: /app/app/dist exists: True
```

Runtime smoke tests of both modes:

- **web** — container boots to `Application startup complete`; `GET /api/list_repos` returns `200 {"status":"success","repositories":[]}`; `GET /` serves the SPA with `200`.
- **mcp** — `CGRAPH_MODE=mcp` answers a JSON-RPC `initialize` handshake, returning `serverInfo.name = "code-graph"`. This previously could not start.

No regression to web mode: `STATIC_DIR` still resolves against `/app/api`, because the working directory takes precedence over `site-packages` on the import path.

## Memory / Performance Impact

N/A — build configuration only, no runtime code changed. Image size is unaffected: the same wheels are installed, just in a different order.

## Related Issues

Follow-up to #723 (review feedback that arrived after merge).
